### PR TITLE
Fix send-raw: base64-encode raw request for Blob scalar

### DIFF
--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -67,10 +67,10 @@ export async function cmdReplay(requestId: string, rawOverride: string | undefin
 export async function cmdSendRaw(host: string, port: number, tls: boolean, raw: string, opts: OutputOpts) {
   const client = await getClient();
 
-  // Create a blank session
+  // Create a blank session (raw must be base64-encoded for the Blob scalar)
   const session = await client.replay.sessions.create({
     requestSource: {
-      raw,
+      raw: btoa(raw),
       connection: { host, port, isTLS: tls },
     },
   });


### PR DESCRIPTION
## Summary
- `cmdSendRaw` in `replay.ts` passes the raw HTTP request as a plain string to `sessions.create()`, but the GraphQL schema expects a `Blob` scalar (base64-encoded)
- The SDK's `replay.send()` handles this encoding internally via `encodeBlob`, but `sessions.create()` does not
- This caused `send-raw` to always fail with: `Expected input type "Blob", found "<raw request>"`
- Fix: wrap with `btoa(raw)` before passing to `sessions.create()`

## Test plan
- [x] `send-raw --host PoC.rhynorater.com --port 443 --tls --raw "GET / HTTP/1.1\r\nHost: PoC.rhynorater.com\r\n\r\n"` now returns 200 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)