### PR TITLE
Add --desc/--latest flag to search command

### DIFF
--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -81,6 +81,7 @@ node caido-client.ts search 'req.method.eq:"POST" AND resp.code.eq:200'
 node caido-client.ts search 'req.host.cont:"api"' --limit 50
 node caido-client.ts search 'req.path.cont:"/admin"' --ids-only
 node caido-client.ts search 'resp.raw.cont:"password"' --after <cursor>
+node caido-client.ts search 'req.host.cont:"target.com"' --desc --limit 5  # newest first
 ```
 
 ### recent - Get recent requests

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -32,6 +32,7 @@ Usage:
     --limit <n>                Max results (default: 20)
     --after <cursor>           Pagination cursor
     --ids-only                 Output only request IDs
+    --desc / --latest          Sort by newest first (descending ID)
 
   recent                       Get recent requests
     --limit <n>                Max results (default: 20)
@@ -224,12 +225,14 @@ async function main() {
       let limit = 20;
       let after: string | undefined;
       let idsOnly = false;
+      let desc = false;
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
         else if (args[i] === "--after" && args[i + 1]) { after = args[i + 1]; i++; }
         else if (args[i] === "--ids-only") { idsOnly = true; }
+        else if (args[i] === "--desc" || args[i] === "--latest") { desc = true; }
       }
-      await cmdSearch(filter, limit, after, idsOnly);
+      await cmdSearch(filter, limit, after, idsOnly, desc);
       break;
     }
 

--- a/skills/caido-mode/lib/commands/requests.ts
+++ b/skills/caido-mode/lib/commands/requests.ts
@@ -4,9 +4,10 @@ import { getClient } from "../client";
 import { decodeRaw, formatHttpRaw, rawToCurl } from "../output";
 import type { OutputOpts } from "../types";
 
-export async function cmdSearch(filter: string, limit: number, after?: string, idsOnly?: boolean) {
+export async function cmdSearch(filter: string, limit: number, after?: string, idsOnly?: boolean, desc?: boolean) {
   const client = await getClient();
   let builder = client.request.list().filter(filter).first(limit);
+  if (desc) builder = builder.descending("req", "id");
   if (after) builder = builder.after(after);
 
   const connection = await builder;


### PR DESCRIPTION
## Summary
- Adds `--desc` / `--latest` flag to the `search` command to sort results by newest first (descending request ID)
- The `recent` command already supports this ordering but doesn't accept HTTPQL filters
- This bridges the gap: full filter support + newest-first ordering

## Changes
- `lib/commands/requests.ts`: Added `desc` parameter to `cmdSearch`, calls `builder.descending("req", "id")` when set
- `caido-client.ts`: Added `--desc`/`--latest` flag parsing and help text

## Usage
```bash
node caido-client.ts search 'req.host.cont:"target.com"' --desc --limit 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)