### PR TITLE
feat(edit): add --session flag to reuse replay tabs

### DIFF
--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -129,6 +129,7 @@ node caido-client.ts edit <id> --method PUT --path /api/admin --body '{"role":"a
 | `--remove-header <Name>` | Remove a header (repeatable) |
 | `--body <content>` | Set request body (auto-updates Content-Length) |
 | `--replace <from>:::<to>` | Find/replace text anywhere in request (repeatable) |
+| `--session <id>` | Reuse existing replay session (iterate in same tab) |
 
 ### replay / send-raw - Send requests
 
@@ -530,7 +531,20 @@ node caido-client.ts create-finding <request-id> --title "IDOR on /api/user/:id"
 node caido-client.ts export-curl <request-id>
 ```
 
-### 2. Privilege Escalation Testing
+### 2. Iterating on a Request (Same Replay Tab)
+
+```bash
+# First edit creates a session — grab the sessionId from output
+node caido-client.ts edit <request-id> --path /api/user/1 --compact
+# Output: { "sessionId": "895", ... }
+
+# Subsequent edits reuse the same tab with --session
+node caido-client.ts edit <request-id> --path /api/user/2 --session 895 --compact
+node caido-client.ts edit <request-id> --path /api/user/3 --session 895 --compact
+node caido-client.ts edit <request-id> --method DELETE --session 895 --compact
+```
+
+### 3. Privilege Escalation Testing
 
 ```bash
 node caido-client.ts search 'req.path.cont:"/admin"' --limit 10
@@ -538,7 +552,7 @@ node caido-client.ts edit <id> --path /api/admin/users --method GET
 node caido-client.ts edit <id> --method POST --body '{"role":"admin"}'
 ```
 
-### 3. Header Bypass Testing
+### 4. Header Bypass Testing
 
 ```bash
 node caido-client.ts edit <id> --set-header "X-Forwarded-For: 127.0.0.1"
@@ -546,7 +560,7 @@ node caido-client.ts edit <id> --set-header "X-Original-URL: /admin"
 node caido-client.ts edit <id> --remove-header "X-CSRF-Token"
 ```
 
-### 4. Fuzzing with Automate
+### 5. Fuzzing with Automate
 
 ```bash
 node caido-client.ts create-automate-session <request-id>
@@ -554,7 +568,7 @@ node caido-client.ts create-automate-session <request-id>
 node caido-client.ts fuzz <session-id>
 ```
 
-### 5. Filter + Analyze Pattern
+### 6. Filter + Analyze Pattern
 
 ```bash
 # Save useful filters

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -56,6 +56,7 @@ Usage:
     --remove-header <name>     Remove header (repeatable)
     --body <body>              Set request body
     --replace <from>:::<to>    Replace text in request (repeatable)
+    --session <id>             Reuse existing replay session (iterate same tab)
 
   export-curl <request-id>     Export request as curl command
 
@@ -283,7 +284,7 @@ async function main() {
 
     case "edit": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
-      let method: string | undefined, path: string | undefined, body: string | undefined;
+      let method: string | undefined, path: string | undefined, body: string | undefined, sessionId: string | undefined;
       const setHeaders: string[] = [], removeHeaders: string[] = [], replacements: string[] = [];
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--method" && args[i + 1]) { method = args[i + 1]; i++; }
@@ -292,8 +293,9 @@ async function main() {
         else if (args[i] === "--set-header" && args[i + 1]) { setHeaders.push(args[i + 1]); i++; }
         else if (args[i] === "--remove-header" && args[i + 1]) { removeHeaders.push(args[i + 1]); i++; }
         else if (args[i] === "--replace" && args[i + 1]) { replacements.push(args[i + 1]); i++; }
+        else if (args[i] === "--session" && args[i + 1]) { sessionId = args[i + 1]; i++; }
       }
-      await cmdEdit(args[1], { method, path, body, setHeaders, removeHeaders, replacements }, parseOutputOpts(args, 2));
+      await cmdEdit(args[1], { method, path, body, setHeaders, removeHeaders, replacements, sessionId }, parseOutputOpts(args, 2));
       break;
     }
 

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -111,6 +111,7 @@ export async function cmdEdit(
     removeHeaders: string[];
     body?: string;
     replacements: string[];
+    sessionId?: string;
   },
   opts: OutputOpts,
 ) {
@@ -189,12 +190,12 @@ export async function cmdEdit(
 
   const modifiedRaw = [requestLine, ...headers].join(lineEnd) + lineEnd + lineEnd + bodyPart;
 
-  // Create session and send
-  const session = await client.replay.sessions.create({
+  // Reuse existing session or create a new one
+  const sessionId = edits.sessionId ?? (await client.replay.sessions.create({
     requestSource: { id: requestId },
-  });
+  })).id;
 
-  const result = await client.replay.send(session.id, {
+  const result = await client.replay.send(sessionId, {
     raw: modifiedRaw,
     connection: {
       host: original.request.host,
@@ -204,7 +205,7 @@ export async function cmdEdit(
   });
 
   const output: Record<string, any> = {
-    sessionId: session.id,
+    sessionId,
     status: result.status,
     error: result.error,
   };


### PR DESCRIPTION
## Summary
- Adds `--session <id>` flag to the `edit` command so subsequent edits can reuse an existing replay session instead of creating a new tab each time
- Previously every `edit` call spawned a new Replay tab, cluttering the UI when iterating on a request (testing multiple paths, parameters, methods, etc.)
- With `--session`, requests stack in the same tab's history — matching the behavior of clicking "Send" repeatedly in Caido's Replay UI

## Usage

```bash
# First edit creates a session — note the sessionId in output
node caido-client.ts edit <id> --path /api/user/1 --compact
# → { "sessionId": "895", ... }

# Subsequent edits reuse the same tab
node caido-client.ts edit <id> --path /api/user/2 --session 895 --compact
node caido-client.ts edit <id> --path /api/user/3 --session 895 --compact
node caido-client.ts edit <id> --method DELETE --session 895 --compact
```

## Changes
- `lib/commands/replay.ts`: Accept optional `sessionId` in edits, reuse existing session via `replay.send()` if provided
- `caido-client.ts`: Parse `--session <id>` flag and pass to `cmdEdit`
- `SKILL.md`: Document the new flag in the options table and add "Iterating on a Request" workflow example

## Test plan
- [x] Verified `edit` without `--session` still creates a new session (backward compatible)
- [x] Verified `edit --session <id>` sends to existing session (tested 3 iterations, all used same sessionId)
- [x] Confirmed requests appear in same Replay tab history in Caido UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)