### PR TITLE
caido-mode v3.1: connection overrides, curl-style --raw, session management

### DIFF
--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -132,16 +132,60 @@ node caido-client.ts edit <id> --method PUT --path /api/admin --body '{"role":"a
 
 ### replay / send-raw - Send requests
 
+`--raw` accepts three formats (like curl's `@` syntax):
+- **String** with C-style escapes: `"GET / HTTP/1.1\r\nHost: x\r\n\r\n"` — `\r\n` converted to real CRLF
+- **@file**: `@request.txt` — reads raw HTTP from file (file should have real CRLF)
+- **Stdin**: `-` — reads from stdin pipe
+
 ```bash
 # Replay as-is
 node caido-client.ts replay <request-id>
 
-# Replay with custom raw
+# Replay with custom raw (C-style escapes)
 node caido-client.ts replay <id> --raw "GET /modified HTTP/1.1\r\nHost: example.com\r\n\r\n"
 
 # Send completely custom request
 node caido-client.ts send-raw --host example.com --port 443 --tls --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+
+# Read raw from file
+node caido-client.ts send-raw --host example.com --tls --raw @request.txt
+
+# Read raw from stdin
+cat request.txt | node caido-client.ts send-raw --host example.com --tls --raw -
+
+# Name the replay session on creation
+node caido-client.ts send-raw --host example.com --tls --raw "..." --name "G /api/test"
+
+# Add to a specific collection
+node caido-client.ts replay <id> --collection 5
+node caido-client.ts send-raw --host example.com --tls --raw "..." --collection 5
 ```
+
+### Connection Overrides (SNI, host routing)
+
+Available on `replay`, `send-raw`, and `edit`:
+
+```bash
+# Override TLS SNI (useful when connecting to IP but need specific SNI)
+node caido-client.ts send-raw --host 1.2.3.4 --tls --sni target.com --raw "..."
+
+# Route to a different host/port than the Host header
+node caido-client.ts replay <id> --connect-host 10.0.0.1 --connect-port 8080
+
+# Force TLS on/off for the override connection
+node caido-client.ts replay <id> --connect-host backend.internal --connect-tls
+node caido-client.ts replay <id> --connect-host backend.internal --connect-no-tls
+```
+
+| Option | Description |
+|--------|-------------|
+| `--sni <hostname>` | TLS Server Name Indication override |
+| `--connect-host <host>` | Connect to different host than Host header |
+| `--connect-port <port>` | Connect to different port |
+| `--connect-tls` | Force TLS on override connection |
+| `--connect-no-tls` | Force plain on override connection |
+| `--collection <id>` | Add session to a specific collection |
+| `--name <name>` | Name the replay session (send-raw only) |
 
 ### export-curl - Convert to curl for PoCs
 
@@ -160,16 +204,41 @@ Outputs a ready-to-use curl command with all headers and body.
 ```bash
 # Create replay session from an existing request
 node caido-client.ts create-session <request-id>
+node caido-client.ts create-session <request-id> --collection 5
 
-# ALWAYS rename sessions for easy identification in Caido UI
-node caido-client.ts rename-session <session-id> "idor-user-profile"
+# ALWAYS rename sessions using the naming convention (see below)
+node caido-client.ts rename-session <session-id> "G /api/user/profile"
+
+# Move session to a collection
+node caido-client.ts move-session <session-id> <collection-id>
 
 # List all replay sessions
 node caido-client.ts replay-sessions
 node caido-client.ts replay-sessions --limit 50
 
+# View replay history for a session
+node caido-client.ts session-entries <session-id>
+node caido-client.ts session-entries <session-id> --limit 50
+node caido-client.ts session-entries <session-id> --raw  # include raw request/response
+
 # Delete replay sessions
 node caido-client.ts delete-sessions <session-id-1>,<session-id-2>
+```
+
+### Session Naming Convention
+
+Name sessions as: `"G|Po|Pu|Pa|De /path/../identifying"`
+
+- **G**=GET, **Po**=POST, **Pu**=PUT, **Pa**=PATCH, **De**=DELETE
+- Use the shortest path fragment that uniquely identifies the endpoint
+- **Reuse the same session** for multiple attack vectors on the same endpoint
+- **Delete sessions** that produced no findings value
+
+Examples:
+```
+"G /api/user/profile"     "Po /auth/login"
+"Pu /admin/settings"      "De /api/records"
+"G /api/../account"       "Po /graphql"
 ```
 
 ### Collections
@@ -574,7 +643,7 @@ node caido-client.ts search 'preset:"API 4xx"' --limit 20
 2. **Workflow**: Search → find request with valid auth → use that ID for all tests via `edit`
 3. **Don't dump raw requests into context** - use `--compact` or `--headers-only` when exploring
 4. **Always check auth first**: `health` to verify connection, then `recent --limit 1`
-5. **ALWAYS NAME REPLAY TABS**: `rename-session <id> "idor-user-profile"`
+5. **ALWAYS NAME REPLAY TABS** using convention: `rename-session <id> "G /api/user/profile"` (G=GET, Po=POST, Pu=PUT, Pa=PATCH, De=DELETE + shortest identifying path). Reuse sessions for the same endpoint. Delete valueless sessions.
 6. **Create findings** for anything interesting - they show up in Caido's Findings tab
 7. **Use `export-curl`** when building PoCs for reports
 8. **Create filter presets** for recurring searches to save typing

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -649,6 +649,32 @@ node caido-client.ts search 'preset:"API 4xx"' --limit 20
 8. **Create filter presets** for recurring searches to save typing
 9. **Use environments** to store test data (victim IDs, tokens, etc.)
 10. **Output is JSON** - parse response fields as needed
+11. **Use replay sessions when you are actively testing the same endpoint across multiple requests** (e.g., iterating on headers/body/parameters for a single path with persisted history and context).
+12. **Never use replay sessions for simple path existence checks or broad path fuzzing.** For these cases, use `curl` directly and proxy traffic through Caido so that all requests still appear in Caido’s HTTP history.
+
+### Curl via Caido Proxy (for path existence checks & fuzzing)
+
+When you just need to check whether a path exists or fuzz many different paths, do **not** create or reuse replay sessions. Instead:
+
+1. **Read Caido’s URL from `secrets.json`** (written by the `setup` command, usually at `~/.claude/config/secrets.json`):
+
+```bash
+CAIDO_URL="$(jq -r '.caido.url' ~/.claude/config/secrets.json)"
+```
+
+2. **Use that URL as curl’s upstream proxy**, so all traffic still flows through Caido:
+
+```bash
+# Single path check
+curl -x "$CAIDO_URL" https://target.example.com/admin -k -i
+
+# Simple path fuzzing example (wordlist.txt contains candidate paths)
+while read -r p; do
+  curl -x "$CAIDO_URL" "https://target.example.com/$p" -k -s -o /dev/null -w "%{http_code} /$p\n"
+done < wordlist.txt
+```
+
+This keeps Caido sessions clean (no noisy replay sessions for basic discovery work) while still capturing every request/response in Caido for later analysis.
 
 ## Performance & Context Optimization
 

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -1,6 +1,6 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env -S npx tsx
 /**
- * Caido SDK Client v3.0
+ * Caido SDK Client v3.1
  * Clean multi-file CLI built entirely on @caido/sdk-client.
  * No raw fetch — uses SDK methods + client.graphql.query/mutation with gql documents.
  */
@@ -9,7 +9,8 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 
 // Commands
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
-import { cmdReplay, cmdSendRaw, cmdEdit, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import { cmdReplay, cmdSendRaw, cmdEdit, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdDeleteSessions, cmdMoveSession, cmdSessionEntries, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import type { ConnectionOverrides } from "./lib/commands/replay";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
@@ -17,9 +18,38 @@ import { cmdViewer, cmdPlugins, cmdHealth, cmdSetup, cmdAuthStatus } from "./lib
 
 const DEBUG = process.env.DEBUG === "1";
 
+/** Parse --sni, --connect-host, --connect-port, --connect-tls from args */
+function parseConnectionOverrides(args: string[], startIdx: number): ConnectionOverrides {
+  const overrides: ConnectionOverrides = {};
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--sni" && args[i + 1]) { overrides.sni = args[i + 1]; i++; }
+    else if (args[i] === "--connect-host" && args[i + 1]) { overrides.connectHost = args[i + 1]; i++; }
+    else if (args[i] === "--connect-port" && args[i + 1]) { overrides.connectPort = parseInt(args[i + 1], 10); i++; }
+    else if (args[i] === "--connect-tls") { overrides.connectTls = true; }
+    else if (args[i] === "--connect-no-tls") { overrides.connectTls = false; }
+  }
+  return overrides;
+}
+
+/** Find --collection <id> in args */
+function parseCollectionId(args: string[], startIdx: number): string | undefined {
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--collection" && args[i + 1]) return args[i + 1];
+  }
+  return undefined;
+}
+
+/** Find --name <name> in args */
+function parseSessionName(args: string[], startIdx: number): string | undefined {
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--name" && args[i + 1]) return args[i + 1];
+  }
+  return undefined;
+}
+
 function printUsage() {
   console.log(`
-Caido SDK Client v3.0 — Built on @caido/sdk-client
+Caido SDK Client v3.1 — Built on @caido/sdk-client
 
 Usage:
   caido-client.ts <command> [options]
@@ -41,13 +71,22 @@ Usage:
   get-response <request-id>    Get just the response for a request
 
   replay <request-id>          Replay a request (blocks until response)
-    --raw <raw-request>        Override with custom raw request
+    --raw <str|@file|->        Override with custom raw request
+    --collection <id>          Add session to this collection
+    --sni <hostname>           TLS Server Name Indication override
+    --connect-host <host>      Connect to different host than Host header
+    --connect-port <port>      Connect to different port
+    --connect-tls              Force TLS on override connection
+    --connect-no-tls           Force plain on override connection
 
   send-raw                     Send a custom raw request
     --host <hostname>          Target host (required)
     --port <port>              Target port (default: 443)
     --tls / --no-tls           Use TLS (default: true)
-    --raw <raw-request>        Raw HTTP request (required)
+    --raw <str|@file|->        Raw HTTP request (required)
+    --sni <hostname>           TLS Server Name Indication override
+    --collection <id>          Add session to this collection
+    --name <session-name>      Name the replay session
 
   edit <request-id>            Edit and replay a request (keeps cookies/auth)
     --method <METHOD>          Change HTTP method
@@ -56,6 +95,10 @@ Usage:
     --remove-header <name>     Remove header (repeatable)
     --body <body>              Set request body
     --replace <from>:::<to>    Replace text in request (repeatable)
+    --collection <id>          Add session to this collection
+    --sni <hostname>           TLS SNI override
+    --connect-host <host>      Connect to different host
+    --connect-port <port>      Connect to different port
 
   export-curl <request-id>     Export request as curl command
 
@@ -64,10 +107,16 @@ Usage:
 ═══════════════════════════════════════════════
 
   create-session <request-id>  Create a replay session from a request
+    --collection <id>          Add to this collection
   rename-session <id> <name>   Rename a replay session
+  move-session <id> <coll-id>  Move a session to a collection
   replay-sessions              List replay sessions
     --limit <n>                Max results (default: 20)
   delete-sessions <id,id,...>  Delete replay sessions
+
+  session-entries <session-id> List replay history for a session
+    --limit <n>                Max results (default: 20)
+    --raw                      Include raw request/response data
 
   replay-collections           List replay collections
     --limit <n>                Max results (default: 20)
@@ -197,13 +246,36 @@ Usage:
     export CAIDO_PAT=<token>
     export CAIDO_URL=http://localhost:8080
 
+═══════════════════════════════════════════════
+ SESSION NAMING CONVENTION
+═══════════════════════════════════════════════
+
+  Name sessions as: "G|Po|Pu|Pa|De /path/../identifying"
+    - G=GET, Po=POST, Pu=PUT, Pa=PATCH, De=DELETE
+    - Use the shortest path fragment that identifies the endpoint
+    - Reuse the same session for multiple attack vectors on one endpoint
+    - Delete sessions that have no findings value
+
+  Examples:
+    "G /api/user/profile"     "Po /auth/login"
+    "Pu /admin/settings"      "De /api/records"
+
+  --raw accepts: string with C-style escapes, @file, or - for stdin
+    "GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n"  → escapes \\r\\n to real CRLF
+    @request.txt                              → read raw from file
+    -                                         → read from stdin (pipe)
+
 Examples:
-  node caido-client.ts search 'req.method.eq:"POST"' --limit 50
-  node caido-client.ts edit 12345 --path /api/admin --method POST
-  node caido-client.ts create-finding 12345 --title "IDOR" --reporter "rez0"
-  node caido-client.ts create-scope "Target" --allow "*.example.com"
-  node caido-client.ts replay-sessions --limit 10
-  node caido-client.ts health
+  caido-client.ts search 'req.method.eq:"POST"' --limit 50
+  caido-client.ts edit 12345 --path /api/admin --method POST
+  caido-client.ts send-raw --host target.com --raw "GET / HTTP/1.1\\r\\nHost: target.com\\r\\n\\r\\n"
+  caido-client.ts send-raw --host target.com --raw @request.txt
+  cat request.txt | caido-client.ts send-raw --host target.com --raw -
+  caido-client.ts send-raw --host 1.2.3.4 --sni target.com --raw "..." --collection 5
+  caido-client.ts replay 123 --connect-host 10.0.0.1 --connect-port 8080
+  caido-client.ts session-entries 42 --limit 10
+  caido-client.ts move-session 42 5
+  caido-client.ts health
 `);
 }
 
@@ -260,7 +332,9 @@ async function main() {
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--raw" && args[i + 1]) { rawOverride = args[i + 1]; i++; }
       }
-      await cmdReplay(args[1], rawOverride, parseOutputOpts(args, 2));
+      const overrides = parseConnectionOverrides(args, 2);
+      const collId = parseCollectionId(args, 2);
+      await cmdReplay(args[1], rawOverride, parseOutputOpts(args, 2), overrides, collId);
       break;
     }
 
@@ -277,7 +351,10 @@ async function main() {
         console.error("Error: --host and --raw are required");
         process.exit(1);
       }
-      await cmdSendRaw(host, port, tls, raw, parseOutputOpts(args, 1));
+      const overrides = parseConnectionOverrides(args, 1);
+      const collId = parseCollectionId(args, 1);
+      const sessName = parseSessionName(args, 1);
+      await cmdSendRaw(host, port, tls, raw, parseOutputOpts(args, 1), overrides, collId, sessName);
       break;
     }
 
@@ -293,7 +370,9 @@ async function main() {
         else if (args[i] === "--remove-header" && args[i + 1]) { removeHeaders.push(args[i + 1]); i++; }
         else if (args[i] === "--replace" && args[i + 1]) { replacements.push(args[i + 1]); i++; }
       }
-      await cmdEdit(args[1], { method, path, body, setHeaders, removeHeaders, replacements }, parseOutputOpts(args, 2));
+      const overrides = parseConnectionOverrides(args, 2);
+      const collId = parseCollectionId(args, 2);
+      await cmdEdit(args[1], { method, path, body, setHeaders, removeHeaders, replacements }, parseOutputOpts(args, 2), overrides, collId);
       break;
     }
 
@@ -306,13 +385,20 @@ async function main() {
     // ── Replay Sessions ──
     case "create-session": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
-      await cmdCreateSession(args[1]);
+      const collId = parseCollectionId(args, 2);
+      await cmdCreateSession(args[1], collId);
       break;
     }
 
     case "rename-session": {
       if (!args[1] || !args[2]) { console.error("Error: session-id and name required"); process.exit(1); }
       await cmdRenameSession(args[1], args[2]);
+      break;
+    }
+
+    case "move-session": {
+      if (!args[1] || !args[2]) { console.error("Error: session-id and collection-id required"); process.exit(1); }
+      await cmdMoveSession(args[1], args[2]);
       break;
     }
 
@@ -328,6 +414,18 @@ async function main() {
     case "delete-sessions": {
       if (!args[1]) { console.error("Error: comma-separated session IDs required"); process.exit(1); }
       await cmdDeleteSessions(args[1].split(",").map(s => s.trim()));
+      break;
+    }
+
+    case "session-entries": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      let limit = 20;
+      let includeRaw = false;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--raw") { includeRaw = true; }
+      }
+      await cmdSessionEntries(args[1], limit, includeRaw);
       break;
     }
 
@@ -534,7 +632,7 @@ async function main() {
     case "setup": {
       const pat = args[1];
       if (!pat) {
-        console.error("Usage: node caido-client.ts setup <pat> [url]");
+        console.error("Usage: caido-client.ts setup <pat> [url]");
         console.error("\nGet a PAT from: Caido → Settings → Developer → Personal Access Tokens");
         process.exit(1);
       }

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -9,37 +9,123 @@ import {
 } from "../graphql";
 import type { OutputOpts } from "../types";
 
+// ── Shared helpers ──
+
+/** Connection override options parsed from CLI */
+export interface ConnectionOverrides {
+  sni?: string;
+  connectHost?: string;
+  connectPort?: number;
+  connectTls?: boolean;
+}
+
+/**
+ * Resolve raw HTTP request value, handling @file, stdin, and C-style escapes.
+ * Follows curl conventions:
+ *   --raw @file.txt       → read from file
+ *   --raw -               → read from stdin
+ *   --raw "GET / ..."     → process C-style escape sequences (\r \n \t \\)
+ */
+export async function resolveRaw(raw: string): Promise<string> {
+  // @file — read from file (like curl -d @file)
+  if (raw.startsWith("@")) {
+    const filePath = raw.slice(1);
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    return (await readFile(resolve(filePath), "utf-8"));
+  }
+
+  // - — read from stdin (like curl -d @-)
+  if (raw === "-") {
+    return await readStdin();
+  }
+
+  // String value — process C-style escapes then ensure CRLF
+  return normalizeRaw(raw);
+}
+
+/** Read all of stdin as a string */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+/**
+ * Process C-style escape sequences in a raw HTTP string.
+ * If the string already contains real CRLF bytes, return as-is.
+ * Otherwise interpret: \r → CR, \n → LF, \t → TAB, \\ → backslash
+ */
+export function normalizeRaw(raw: string): string {
+  // If the raw already contains real CR characters, it's fine
+  if (raw.includes("\r\n")) return raw;
+  // Process C-style escape sequences
+  return raw.replace(/\\([rnt\\])/g, (_, ch) => {
+    switch (ch) {
+      case "r": return "\r";
+      case "n": return "\n";
+      case "t": return "\t";
+      case "\\": return "\\";
+      default: return ch;
+    }
+  });
+}
+
+/** Build connection info with overrides */
+function buildConnection(
+  host: string,
+  port: number,
+  isTLS: boolean,
+  overrides?: ConnectionOverrides,
+) {
+  const conn: Record<string, any> = {
+    host: overrides?.connectHost ?? host,
+    port: overrides?.connectPort ?? port,
+    isTLS: overrides?.connectTls ?? isTLS,
+  };
+  if (overrides?.sni) {
+    conn.SNI = overrides.sni;
+  }
+  return conn;
+}
+
 // ── Replay ──
 
-export async function cmdReplay(requestId: string, rawOverride: string | undefined, opts: OutputOpts) {
+export async function cmdReplay(
+  requestId: string,
+  rawOverride: string | undefined,
+  opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
+) {
   const client = await getClient();
 
-  // Get the original request to extract connection info
   const original = await client.request.get(requestId, { raw: true });
   if (!original) {
     console.error(`Request ${requestId} not found`);
     process.exit(1);
   }
 
-  // Create a temporary replay session
-  const session = await client.replay.sessions.create({
-    requestSource: { id: requestId },
-  });
+  const createOpts: any = { requestSource: { id: requestId } };
+  if (collectionId) createOpts.collectionId = collectionId;
+  const session = await client.replay.sessions.create(createOpts);
 
-  const raw = rawOverride || decodeRaw(original.request.raw);
+  let raw = rawOverride ? await resolveRaw(rawOverride) : decodeRaw(original.request.raw);
   if (!raw) {
     console.error("No raw data for this request");
     process.exit(1);
   }
 
-  const result = await client.replay.send(session.id, {
-    raw,
-    connection: {
-      host: original.request.host,
-      port: original.request.port,
-      isTLS: original.request.isTls,
-    },
-  });
+  const connection = buildConnection(
+    original.request.host,
+    original.request.port,
+    original.request.isTls,
+    overrides,
+  );
+
+  const result = await client.replay.send(session.id, { raw, connection });
 
   const output: Record<string, any> = {
     sessionId: session.id,
@@ -49,6 +135,9 @@ export async function cmdReplay(requestId: string, rawOverride: string | undefin
 
   if (result.entry) {
     output.entryId = result.entry.id;
+    if (result.entry.request) {
+      output.requestId = result.entry.request.id;
+    }
     if (result.entry.response) {
       output.response = {
         statusCode: result.entry.response.statusCode,
@@ -64,21 +153,38 @@ export async function cmdReplay(requestId: string, rawOverride: string | undefin
   console.log(JSON.stringify(output, null, 2));
 }
 
-export async function cmdSendRaw(host: string, port: number, tls: boolean, raw: string, opts: OutputOpts) {
+export async function cmdSendRaw(
+  host: string,
+  port: number,
+  tls: boolean,
+  raw: string,
+  opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
+  sessionName?: string,
+) {
   const client = await getClient();
 
-  // Create a blank session
-  const session = await client.replay.sessions.create({
-    requestSource: {
-      raw,
-      connection: { host, port, isTLS: tls },
-    },
-  });
+  raw = await resolveRaw(raw);
+  const rawB64 = btoa(raw);
 
-  const result = await client.replay.send(session.id, {
-    raw,
-    connection: { host, port, isTLS: tls },
-  });
+  const connection = buildConnection(host, port, tls, overrides);
+
+  const createOpts: any = {
+    requestSource: {
+      raw: rawB64,
+      connection,
+    },
+  };
+  if (collectionId) createOpts.collectionId = collectionId;
+
+  const session = await client.replay.sessions.create(createOpts);
+
+  if (sessionName) {
+    await client.replay.sessions.rename(session.id, sessionName);
+  }
+
+  const result = await client.replay.send(session.id, { raw, connection });
 
   const output: Record<string, any> = {
     sessionId: session.id,
@@ -86,14 +192,20 @@ export async function cmdSendRaw(host: string, port: number, tls: boolean, raw: 
     error: result.error,
   };
 
-  if (result.entry?.response) {
-    output.response = {
-      statusCode: result.entry.response.statusCode,
-      roundtrip: result.entry.response.roundtripTime,
-      length: result.entry.response.length,
-    };
-    if (result.entry.response.raw) {
-      output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
+  if (result.entry) {
+    output.entryId = result.entry.id;
+    if (result.entry.request) {
+      output.requestId = result.entry.request.id;
+    }
+    if (result.entry.response) {
+      output.response = {
+        statusCode: result.entry.response.statusCode,
+        roundtrip: result.entry.response.roundtripTime,
+        length: result.entry.response.length,
+      };
+      if (result.entry.response.raw) {
+        output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
+      }
     }
   }
 
@@ -113,6 +225,8 @@ export async function cmdEdit(
     replacements: string[];
   },
   opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
 ) {
   const client = await getClient();
   const original = await client.request.get(requestId, { raw: true });
@@ -189,19 +303,18 @@ export async function cmdEdit(
 
   const modifiedRaw = [requestLine, ...headers].join(lineEnd) + lineEnd + lineEnd + bodyPart;
 
-  // Create session and send
-  const session = await client.replay.sessions.create({
-    requestSource: { id: requestId },
-  });
+  const createOpts: any = { requestSource: { id: requestId } };
+  if (collectionId) createOpts.collectionId = collectionId;
+  const session = await client.replay.sessions.create(createOpts);
 
-  const result = await client.replay.send(session.id, {
-    raw: modifiedRaw,
-    connection: {
-      host: original.request.host,
-      port: original.request.port,
-      isTLS: original.request.isTls,
-    },
-  });
+  const connection = buildConnection(
+    original.request.host,
+    original.request.port,
+    original.request.isTls,
+    overrides,
+  );
+
+  const result = await client.replay.send(session.id, { raw: modifiedRaw, connection });
 
   const output: Record<string, any> = {
     sessionId: session.id,
@@ -213,14 +326,20 @@ export async function cmdEdit(
     output.modifiedRequest = formatHttpRaw(modifiedRaw, opts);
   }
 
-  if (result.entry?.response) {
-    output.response = {
-      statusCode: result.entry.response.statusCode,
-      roundtrip: result.entry.response.roundtripTime,
-      length: result.entry.response.length,
-    };
-    if (result.entry.response.raw) {
-      output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
+  if (result.entry) {
+    output.entryId = result.entry.id;
+    if (result.entry.request) {
+      output.requestId = result.entry.request.id;
+    }
+    if (result.entry.response) {
+      output.response = {
+        statusCode: result.entry.response.statusCode,
+        roundtrip: result.entry.response.roundtripTime,
+        length: result.entry.response.length,
+      };
+      if (result.entry.response.raw) {
+        output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
+      }
     }
   }
 
@@ -243,11 +362,11 @@ export async function cmdReplaySessions(limit: number) {
   console.log(JSON.stringify({ results, count: results.length }, null, 2));
 }
 
-export async function cmdCreateSession(requestId: string) {
+export async function cmdCreateSession(requestId: string, collectionId?: string) {
   const client = await getClient();
-  const session = await client.replay.sessions.create({
-    requestSource: { id: requestId },
-  });
+  const createOpts: any = { requestSource: { id: requestId } };
+  if (collectionId) createOpts.collectionId = collectionId;
+  const session = await client.replay.sessions.create(createOpts);
   console.log(JSON.stringify({
     id: session.id,
     name: session.name,
@@ -265,6 +384,79 @@ export async function cmdDeleteSessions(ids: string[]) {
   const client = await getClient();
   await client.replay.sessions.delete(ids);
   console.log(JSON.stringify({ deleted: ids }, null, 2));
+}
+
+export async function cmdMoveSession(sessionId: string, collectionId: string) {
+  const client = await getClient();
+  const session = await client.replay.sessions.move(sessionId, collectionId);
+  console.log(JSON.stringify({
+    id: session.id,
+    name: session.name,
+    collectionId: session.collectionId,
+    moved: true,
+  }, null, 2));
+}
+
+export async function cmdSessionEntries(sessionId: string, limit: number, includeRaw: boolean) {
+  const client = await getClient();
+  const session = await client.replay.sessions.get(sessionId);
+  if (!session) {
+    console.error(`Session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  let builder = session.entries();
+  if (includeRaw) {
+    builder = builder.includeRaw({ request: true, response: true, replay: false });
+  }
+  const connection = await builder.first(limit);
+
+  const results = connection.edges.map(e => {
+    const entry: Record<string, any> = {
+      id: e.node.id,
+      sessionId: e.node.sessionId,
+      createdAt: e.node.createdAt,
+      error: e.node.error,
+    };
+
+    if (e.node.connection) {
+      entry.connection = {
+        host: e.node.connection.host,
+        port: e.node.connection.port,
+        isTLS: e.node.connection.isTLS,
+        ...(e.node.connection.SNI ? { SNI: e.node.connection.SNI } : {}),
+      };
+    }
+
+    if (e.node.request) {
+      entry.request = {
+        id: e.node.request.id,
+        method: e.node.request.method,
+        host: e.node.request.host,
+        port: e.node.request.port,
+        path: e.node.request.path,
+        isTls: e.node.request.isTls,
+      };
+    }
+
+    if (e.node.response) {
+      entry.response = {
+        statusCode: e.node.response.statusCode,
+        roundtrip: e.node.response.roundtripTime,
+        length: e.node.response.length,
+      };
+    }
+
+    return entry;
+  });
+
+  console.log(JSON.stringify({
+    sessionId,
+    sessionName: session.name,
+    activeEntryId: session.activeEntryId,
+    results,
+    count: results.length,
+  }, null, 2));
 }
 
 // ── Collections ──


### PR DESCRIPTION
## Summary

- **Fix shebang**: `node` → `npx tsx` (Node v22 can't run `.ts` files natively, was causing `ERR_UNKNOWN_FILE_EXTENSION`)
- **Curl-style `--raw`**: now accepts `@file` (read from file), `-` (stdin pipe), or string with C-style escape processing (`\r`, `\n`, `\t`, `\\`)
- **Connection overrides**: `--sni`, `--connect-host`, `--connect-port`, `--connect-tls/--connect-no-tls` on `replay`, `send-raw`, and `edit` — routes TCP to a different target while preserving HTTP Host header
- **Collection support**: `--collection <id>` on `replay`, `send-raw`, `edit`, `create-session` to assign sessions to collections on creation
- **Session naming**: `--name` option on `send-raw`, plus documented naming convention (`G|Po|Pu|Pa|De /path/../identifying`)
- **New commands**: `session-entries` (view replay history with optional raw data), `move-session` (move between collections)
- **Richer output**: all send commands now return `entryId` and `requestId`; `session-entries` includes SNI in connection info

All features use existing SDK methods — no new GraphQL queries or raw fetch needed.

## Test plan

- [x] `health` — verify tsx shebang works
- [x] `send-raw` with C-style escape string — CRLF normalization produces valid HTTP
- [x] `send-raw --raw @file.txt` — reads raw from file
- [x] `send-raw --name "..."` — session gets named
- [x] `session-entries <id>` — lists entries with connection info
- [x] `move-session <id> <collection-id>` — moves session
- [x] `replay-sessions` — lists sessions with correct metadata
- [x] Cleanup: test sessions deleted after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)