### PR TITLE
Add session lookup commands for direct replay tab access

### DIFF
--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -16,6 +16,7 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 |----------|----------|
 | **HTTP History** | `search`, `recent`, `get`, `get-response`, `export-curl` |
 | **Edit & Replay** | `edit`, `replay`, `send-raw` |
+| **Session Lookup** | `get-session`, `replay-entries`, `edit-session` |
 | **Sessions** | `create-session`, `rename-session`, `replay-sessions`, `delete-sessions` |
 | **Collections** | `replay-collections`, `create-collection`, `rename-collection`, `delete-collection` |
 | **Fuzzing** | `create-automate-session`, `fuzz` |
@@ -154,6 +155,24 @@ node caido-client.ts create-env "IDOR-Test"
 node caido-client.ts env-set <env-id> victim_id "user_456"
 node caido-client.ts select-env <env-id>
 node caido-client.ts delete-env <id>
+```
+
+### Session Lookup (tab number = session ID)
+
+Caido's replay tab number maps directly to the session ID. No pagination needed.
+
+```bash
+# Instantly see what's in replay tab 412
+node caido-client.ts get-session 412
+node caido-client.ts get-session 412 --compact
+
+# List request history within a replay tab
+node caido-client.ts replay-entries 412 --limit 10
+
+# Edit and send from the tab's active request directly
+node caido-client.ts edit-session 412 --body '{"test": true}' --compact
+node caido-client.ts edit-session 412 --path /api/other --compact
+node caido-client.ts edit-session 412 --replace "old_value:::new_value" --compact
 ```
 
 ### Sessions & Collections

--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -157,22 +157,21 @@ node caido-client.ts select-env <env-id>
 node caido-client.ts delete-env <id>
 ```
 
-### Session Lookup (tab number = session ID)
+### Session Lookup (by tab number or name)
 
-Caido's replay tab number maps directly to the session ID. No pagination needed.
+Caido's replay tab number maps directly to the session ID. Renamed tabs can also be looked up by name.
 
 ```bash
-# Instantly see what's in replay tab 412
+# Look up by tab number (instant) or by name (scans sessions)
 node caido-client.ts get-session 412
-node caido-client.ts get-session 412 --compact
+node caido-client.ts get-session "testing_idor" --compact
 
 # List request history within a replay tab
 node caido-client.ts replay-entries 412 --limit 10
 
 # Edit and send from the tab's active request directly
 node caido-client.ts edit-session 412 --body '{"test": true}' --compact
-node caido-client.ts edit-session 412 --path /api/other --compact
-node caido-client.ts edit-session 412 --replace "old_value:::new_value" --compact
+node caido-client.ts edit-session "testing_idor" --path /api/other --compact
 ```
 
 ### Sessions & Collections

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -153,6 +153,29 @@ Outputs a ready-to-use curl command with all headers and body.
 
 ---
 
+## Session Lookup (tab number = session ID)
+
+Caido's replay tab number in the UI corresponds directly to the session ID in the API.
+
+```bash
+# Look up exactly what's in replay tab 412 (no pagination needed!)
+node caido-client.ts get-session 412
+node caido-client.ts get-session 412 --compact
+
+# List request history within a replay tab
+node caido-client.ts replay-entries 412
+node caido-client.ts replay-entries 412 --limit 50
+
+# Edit and send from a replay tab's active request (no request-id needed)
+node caido-client.ts edit-session 412 --body '{"test": true}' --compact
+node caido-client.ts edit-session 412 --path /api/other --compact
+node caido-client.ts edit-session 412 --replace "old_value:::new_value" --compact
+```
+
+**Key insight**: `get-session` + `edit-session` eliminate the need to search through history to find the right request. The user says "replay tab 412" and you use session ID 412 directly.
+
+---
+
 ## Replay Sessions & Collections
 
 ### Sessions
@@ -571,7 +594,8 @@ node caido-client.ts search 'preset:"API 4xx"' --limit 20
 ## Instructions for Claude
 
 1. **PREFER `edit` OVER `replay --raw`** - preserves cookies/auth automatically
-2. **Workflow**: Search → find request with valid auth → use that ID for all tests via `edit`
+2. **When user says "replay tab N"**: Use `get-session N` to see it, `edit-session N` to modify and send — no search needed
+3. **Workflow**: Search → find request with valid auth → use that ID for all tests via `edit`
 3. **Don't dump raw requests into context** - use `--compact` or `--headers-only` when exploring
 4. **Always check auth first**: `health` to verify connection, then `recent --limit 1`
 5. **ALWAYS NAME REPLAY TABS**: `rename-session <id> "idor-user-profile"`

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -153,26 +153,29 @@ Outputs a ready-to-use curl command with all headers and body.
 
 ---
 
-## Session Lookup (tab number = session ID)
+## Session Lookup (by tab number or name)
 
-Caido's replay tab number in the UI corresponds directly to the session ID in the API.
+Caido's replay tab number in the UI corresponds directly to the session ID in the API. Renamed tabs can also be looked up by name.
 
 ```bash
-# Look up exactly what's in replay tab 412 (no pagination needed!)
+# Look up by tab number (instant ID lookup)
 node caido-client.ts get-session 412
 node caido-client.ts get-session 412 --compact
 
+# Look up by name (if the tab was renamed)
+node caido-client.ts get-session "testing_idor"
+
 # List request history within a replay tab
 node caido-client.ts replay-entries 412
-node caido-client.ts replay-entries 412 --limit 50
+node caido-client.ts replay-entries "testing_idor" --limit 50
 
 # Edit and send from a replay tab's active request (no request-id needed)
 node caido-client.ts edit-session 412 --body '{"test": true}' --compact
-node caido-client.ts edit-session 412 --path /api/other --compact
+node caido-client.ts edit-session "testing_idor" --path /api/other --compact
 node caido-client.ts edit-session 412 --replace "old_value:::new_value" --compact
 ```
 
-**Key insight**: `get-session` + `edit-session` eliminate the need to search through history to find the right request. The user says "replay tab 412" and you use session ID 412 directly.
+**Key insight**: `get-session` + `edit-session` eliminate the need to search through history to find the right request. The user says "replay tab 412" or "the testing_idor tab" and you look it up directly.
 
 ---
 
@@ -594,7 +597,7 @@ node caido-client.ts search 'preset:"API 4xx"' --limit 20
 ## Instructions for Claude
 
 1. **PREFER `edit` OVER `replay --raw`** - preserves cookies/auth automatically
-2. **When user says "replay tab N"**: Use `get-session N` to see it, `edit-session N` to modify and send — no search needed
+2. **When user says "replay tab N" or "the X tab"**: Use `get-session N` (or `get-session "name"`) to see it, `edit-session` to modify and send — no search needed
 3. **Workflow**: Search → find request with valid auth → use that ID for all tests via `edit`
 3. **Don't dump raw requests into context** - use `--compact` or `--headers-only` when exploring
 4. **Always check auth first**: `health` to verify connection, then `recent --limit 1`

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -9,7 +9,7 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 
 // Commands
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
-import { cmdReplay, cmdSendRaw, cmdEdit, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import { cmdReplay, cmdSendRaw, cmdEdit, cmdEditSession, cmdGetSession, cmdReplayEntries, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
@@ -58,6 +58,21 @@ Usage:
     --replace <from>:::<to>    Replace text in request (repeatable)
 
   export-curl <request-id>     Export request as curl command
+
+═══════════════════════════════════════════════
+ SESSION LOOKUP (tab number = session ID)
+═══════════════════════════════════════════════
+
+  get-session <session-id>     Get replay tab by ID (shows active request)
+  replay-entries <session-id>  List request history within a replay tab
+    --limit <n>                Max results (default: 20)
+  edit-session <session-id>    Edit & send from a replay tab's active request
+    --method <METHOD>          Change HTTP method
+    --path <path>              Change request path
+    --set-header <N:V>         Set header (repeatable)
+    --remove-header <name>     Remove header (repeatable)
+    --body <body>              Set request body
+    --replace <from>:::<to>    Replace text in request (repeatable)
 
 ═══════════════════════════════════════════════
  REPLAY SESSIONS & COLLECTIONS
@@ -300,6 +315,39 @@ async function main() {
     case "export-curl": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
       await cmdExportCurl(args[1]);
+      break;
+    }
+
+    // ── Session Lookup ──
+    case "get-session": {
+      if (!args[1]) { console.error("Error: session-id required (matches tab number in Caido UI)"); process.exit(1); }
+      await cmdGetSession(args[1], parseOutputOpts(args, 2));
+      break;
+    }
+
+    case "replay-entries": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      let reLimit = 20;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--limit" && args[i + 1]) { reLimit = parseInt(args[i + 1], 10); i++; }
+      }
+      await cmdReplayEntries(args[1], reLimit, parseOutputOpts(args, 2));
+      break;
+    }
+
+    case "edit-session": {
+      if (!args[1]) { console.error("Error: session-id required (matches tab number in Caido UI)"); process.exit(1); }
+      let esMethod: string | undefined, esPath: string | undefined, esBody: string | undefined;
+      const esSetHeaders: string[] = [], esRemoveHeaders: string[] = [], esReplacements: string[] = [];
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--method" && args[i + 1]) { esMethod = args[i + 1]; i++; }
+        else if (args[i] === "--path" && args[i + 1]) { esPath = args[i + 1]; i++; }
+        else if (args[i] === "--body" && args[i + 1]) { esBody = args[i + 1]; i++; }
+        else if (args[i] === "--set-header" && args[i + 1]) { esSetHeaders.push(args[i + 1]); i++; }
+        else if (args[i] === "--remove-header" && args[i + 1]) { esRemoveHeaders.push(args[i + 1]); i++; }
+        else if (args[i] === "--replace" && args[i + 1]) { esReplacements.push(args[i + 1]); i++; }
+      }
+      await cmdEditSession(args[1], { method: esMethod, path: esPath, body: esBody, setHeaders: esSetHeaders, removeHeaders: esRemoveHeaders, replacements: esReplacements }, parseOutputOpts(args, 2));
       break;
     }
 

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -60,13 +60,13 @@ Usage:
   export-curl <request-id>     Export request as curl command
 
 ═══════════════════════════════════════════════
- SESSION LOOKUP (tab number = session ID)
+ SESSION LOOKUP (by tab number OR name)
 ═══════════════════════════════════════════════
 
-  get-session <session-id>     Get replay tab by ID (shows active request)
-  replay-entries <session-id>  List request history within a replay tab
+  get-session <id-or-name>     Get replay tab by ID or name (shows active request)
+  replay-entries <id-or-name>  List request history within a replay tab
     --limit <n>                Max results (default: 20)
-  edit-session <session-id>    Edit & send from a replay tab's active request
+  edit-session <id-or-name>    Edit & send from a replay tab's active request
     --method <METHOD>          Change HTTP method
     --path <path>              Change request path
     --set-header <N:V>         Set header (repeatable)
@@ -320,7 +320,7 @@ async function main() {
 
     // ── Session Lookup ──
     case "get-session": {
-      if (!args[1]) { console.error("Error: session-id required (matches tab number in Caido UI)"); process.exit(1); }
+      if (!args[1]) { console.error("Error: session id or name required"); process.exit(1); }
       await cmdGetSession(args[1], parseOutputOpts(args, 2));
       break;
     }
@@ -336,7 +336,7 @@ async function main() {
     }
 
     case "edit-session": {
-      if (!args[1]) { console.error("Error: session-id required (matches tab number in Caido UI)"); process.exit(1); }
+      if (!args[1]) { console.error("Error: session id or name required"); process.exit(1); }
       let esMethod: string | undefined, esPath: string | undefined, esBody: string | undefined;
       const esSetHeaders: string[] = [], esRemoveHeaders: string[] = [], esReplacements: string[] = [];
       for (let i = 2; i < args.length; i++) {

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -9,6 +9,35 @@ import {
 } from "../graphql";
 import type { OutputOpts } from "../types";
 
+// ── Resolve session by ID or name ──
+
+async function resolveSession(client: any, idOrName: string) {
+  // Try direct ID lookup first (may throw on non-numeric strings)
+  try {
+    const byId = await client.replay.sessions.get(idOrName);
+    if (byId) return byId;
+  } catch {
+    // ID lookup failed (e.g., non-numeric string) — fall through to name search
+  }
+
+  // Fall back to searching by name (paginate in chunks of 100)
+  let after: string | undefined;
+  while (true) {
+    const page = after
+      ? await client.replay.sessions.list().after(after, 100)
+      : await client.replay.sessions.list().first(100);
+
+    for (const edge of page.edges) {
+      if (edge.node.name === idOrName) return edge.node;
+    }
+
+    if (!page.pageInfo.hasNextPage) break;
+    after = page.pageInfo.endCursor;
+  }
+
+  return undefined;
+}
+
 // ── Replay ──
 
 export async function cmdReplay(requestId: string, rawOverride: string | undefined, opts: OutputOpts) {
@@ -231,10 +260,10 @@ export async function cmdEdit(
 
 export async function cmdGetSession(sessionId: string, opts: OutputOpts) {
   const client = await getClient();
-  const session = await client.replay.sessions.get(sessionId);
+  const session = await resolveSession(client, sessionId);
 
   if (!session) {
-    console.error(`Replay session ${sessionId} not found`);
+    console.error(`Replay session "${sessionId}" not found (tried ID and name lookup)`);
     process.exit(1);
   }
 
@@ -296,10 +325,10 @@ export async function cmdGetSession(sessionId: string, opts: OutputOpts) {
 
 export async function cmdReplayEntries(sessionId: string, limit: number, opts: OutputOpts) {
   const client = await getClient();
-  const session = await client.replay.sessions.get(sessionId);
+  const session = await resolveSession(client, sessionId);
 
   if (!session) {
-    console.error(`Replay session ${sessionId} not found`);
+    console.error(`Replay session "${sessionId}" not found (tried ID and name lookup)`);
     process.exit(1);
   }
 
@@ -337,7 +366,7 @@ export async function cmdReplayEntries(sessionId: string, limit: number, opts: O
 // ── Edit from Session (use active entry as source) ──
 
 export async function cmdEditSession(
-  sessionId: string,
+  sessionIdOrName: string,
   edits: {
     method?: string;
     path?: string;
@@ -349,12 +378,14 @@ export async function cmdEditSession(
   opts: OutputOpts,
 ) {
   const client = await getClient();
-  const session = await client.replay.sessions.get(sessionId);
+  const session = await resolveSession(client, sessionIdOrName);
 
   if (!session) {
-    console.error(`Replay session ${sessionId} not found`);
+    console.error(`Replay session "${sessionIdOrName}" not found (tried ID and name lookup)`);
     process.exit(1);
   }
+
+  const sessionId = session.id;
 
   if (!session.activeEntryId) {
     console.error(`Session ${sessionId} has no active entry`);

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -227,6 +227,245 @@ export async function cmdEdit(
   console.log(JSON.stringify(output, null, 2));
 }
 
+// ── Get Session (by ID — matches tab number in UI) ──
+
+export async function cmdGetSession(sessionId: string, opts: OutputOpts) {
+  const client = await getClient();
+  const session = await client.replay.sessions.get(sessionId);
+
+  if (!session) {
+    console.error(`Replay session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  const output: Record<string, any> = {
+    id: session.id,
+    name: session.name,
+    collectionId: session.collectionId,
+    activeEntryId: session.activeEntryId,
+  };
+
+  // If there's an active entry, fetch its details
+  if (session.activeEntryId) {
+    const entry = await client.replay.entries.get(session.activeEntryId);
+    if (entry) {
+      output.activeEntry = {
+        id: entry.id,
+        sessionId: entry.sessionId,
+        connection: {
+          host: entry.connection.host,
+          port: entry.connection.port,
+          isTLS: (entry.connection as any).isTLS ?? (entry.connection as any).isTls,
+        },
+        createdAt: entry.createdAt,
+        error: entry.error,
+      };
+
+      if (entry.request) {
+        output.activeEntry.request = {
+          id: entry.request.id,
+          method: entry.request.method,
+          host: entry.request.host,
+          path: entry.request.path,
+          port: entry.request.port,
+          isTls: entry.request.isTls,
+        };
+      }
+
+      if (entry.raw) {
+        output.activeEntry.raw = formatHttpRaw(decodeRaw(entry.raw), opts);
+      }
+
+      if (entry.response) {
+        output.activeEntry.response = {
+          statusCode: entry.response.statusCode,
+          roundtrip: entry.response.roundtripTime,
+          length: entry.response.length,
+        };
+        if (entry.response.raw) {
+          output.activeEntry.response.raw = formatHttpRaw(decodeRaw(entry.response.raw), opts);
+        }
+      }
+    }
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+// ── Replay Entries (list entries within a session) ──
+
+export async function cmdReplayEntries(sessionId: string, limit: number, opts: OutputOpts) {
+  const client = await getClient();
+  const session = await client.replay.sessions.get(sessionId);
+
+  if (!session) {
+    console.error(`Replay session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  const connection = await session.entries().includeRaw({ request: false, response: false, replay: false }).first(limit);
+
+  const results = connection.edges.map(e => ({
+    id: e.node.id,
+    sessionId: e.node.sessionId,
+    createdAt: e.node.createdAt,
+    error: e.node.error,
+    connection: {
+      host: e.node.connection.host,
+      port: e.node.connection.port,
+      isTLS: (e.node.connection as any).isTLS ?? (e.node.connection as any).isTls,
+    },
+    request: e.node.request ? {
+      method: e.node.request.method,
+      host: e.node.request.host,
+      path: e.node.request.path,
+      statusCode: e.node.response?.statusCode,
+      roundtrip: e.node.response?.roundtripTime,
+      responseLength: e.node.response?.length,
+    } : undefined,
+  }));
+
+  console.log(JSON.stringify({
+    sessionId,
+    sessionName: session.name,
+    activeEntryId: session.activeEntryId,
+    results,
+    count: results.length,
+  }, null, 2));
+}
+
+// ── Edit from Session (use active entry as source) ──
+
+export async function cmdEditSession(
+  sessionId: string,
+  edits: {
+    method?: string;
+    path?: string;
+    setHeaders: string[];
+    removeHeaders: string[];
+    body?: string;
+    replacements: string[];
+  },
+  opts: OutputOpts,
+) {
+  const client = await getClient();
+  const session = await client.replay.sessions.get(sessionId);
+
+  if (!session) {
+    console.error(`Replay session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  if (!session.activeEntryId) {
+    console.error(`Session ${sessionId} has no active entry`);
+    process.exit(1);
+  }
+
+  const entry = await client.replay.entries.get(session.activeEntryId);
+  if (!entry || !entry.raw) {
+    console.error(`Could not get raw data for active entry ${session.activeEntryId}`);
+    process.exit(1);
+  }
+
+  let raw = decodeRaw(entry.raw);
+  if (!raw) {
+    console.error("No raw data for the active entry");
+    process.exit(1);
+  }
+
+  // Apply replacements
+  for (const rep of edits.replacements) {
+    const [from, to] = rep.split(":::");
+    if (from && to !== undefined) {
+      raw = raw.replaceAll(from, to);
+    }
+  }
+
+  // Parse request line and headers
+  const lineEnd = raw.indexOf("\r\n") >= 0 ? "\r\n" : "\n";
+  const parts = raw.split(lineEnd + lineEnd);
+  const headerBlock = parts[0];
+  let bodyPart = parts.slice(1).join(lineEnd + lineEnd);
+
+  const headerLines = headerBlock.split(lineEnd);
+  let requestLine = headerLines[0];
+  let headers = headerLines.slice(1);
+
+  // Modify method
+  if (edits.method) {
+    const spaceIdx = requestLine.indexOf(" ");
+    if (spaceIdx > 0) {
+      requestLine = edits.method + requestLine.substring(spaceIdx);
+    }
+  }
+
+  // Modify path
+  if (edits.path) {
+    const firstSpace = requestLine.indexOf(" ");
+    const lastSpace = requestLine.lastIndexOf(" ");
+    if (firstSpace > 0 && lastSpace > firstSpace) {
+      requestLine = requestLine.substring(0, firstSpace + 1) + edits.path + requestLine.substring(lastSpace);
+    }
+  }
+
+  // Remove headers
+  for (const name of edits.removeHeaders) {
+    headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
+  }
+
+  // Set headers
+  for (const header of edits.setHeaders) {
+    const colonIdx = header.indexOf(":");
+    if (colonIdx > 0) {
+      const name = header.substring(0, colonIdx).trim();
+      headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
+      headers.push(header.trim());
+    }
+  }
+
+  // Set body
+  if (edits.body !== undefined) {
+    bodyPart = edits.body;
+    const clBytes = new TextEncoder().encode(bodyPart).length;
+    headers = headers.filter(h => !h.toLowerCase().startsWith("content-length:"));
+    headers.push(`Content-Length: ${clBytes}`);
+  }
+
+  const modifiedRaw = [requestLine, ...headers].join(lineEnd) + lineEnd + lineEnd + bodyPart;
+
+  const result = await client.replay.send(sessionId, {
+    raw: modifiedRaw,
+    connection: {
+      host: entry.connection.host,
+      port: entry.connection.port,
+      isTLS: (entry.connection as any).isTLS ?? (entry.connection as any).isTls,
+    },
+  });
+
+  const output: Record<string, any> = {
+    sessionId,
+    status: result.status,
+    error: result.error,
+  };
+
+  if (!opts.noRequest) {
+    output.modifiedRequest = formatHttpRaw(modifiedRaw, opts);
+  }
+
+  if (result.entry?.response) {
+    output.response = {
+      statusCode: result.entry.response.statusCode,
+      roundtrip: result.entry.response.roundtripTime,
+      length: result.entry.response.length,
+    };
+    if (result.entry.response.raw) {
+      output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
+    }
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
 // ── Sessions ──
 
 export async function cmdReplaySessions(limit: number) {


### PR DESCRIPTION
## Summary

- Adds `get-session`, `replay-entries`, and `edit-session` commands that let AI agents (and humans) work directly with Caido replay tabs by their tab number
- The replay tab number in the UI maps 1:1 to the session ID in the API, but previously there was no way to look up a session by ID — you had to paginate through all sessions with `replay-sessions --limit 200+`
- Uses existing SDK methods (`sessions.get()`, `entries.get()`, `session.entries()`) that were available but not exposed in the CLI

## New commands

| Command | Purpose |
|---------|---------|
| `get-session <id>` | Look up a replay tab by number — returns active entry's raw request, response, connection |
| `replay-entries <id>` | List request history within a replay tab |
| `edit-session <id>` | Edit and send from tab's active request (no history request-id needed) |

## Example workflow

```bash
# User says "I'm in replay tab 412"
node caido-client.ts get-session 412 --compact

# Iterate on the request directly
node caido-client.ts edit-session 412 --body '{"html":"<b>test</b>"}' --compact
node caido-client.ts edit-session 412 --body '{"html":"<img src=x>"}' --compact
```

## Test plan

- [ ] Verify `get-session` returns correct session info and active entry details
- [ ] Verify `replay-entries` lists entries within a session
- [ ] Verify `edit-session` modifies and sends requests using the session's active entry as source
- [ ] Verify session ID matches tab number in Caido UI


🤖 Generated with [Claude Code](https://claude.com/claude-code)