### PR TITLE
fix: replace deprecated pnpx with pnpm dlx in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Collection of skills to interact with Caido.
 ## Installation
 
 ```bash
-pnpx skills add caido/skills --skill='*'
+pnpm dlx skills add caido/skills --skill='*'
 ```
 
 or to install all of them globally:
 
 ```bash
-pnpx skills add caido/skills --skill='*' -g
+pnpm dlx skills add caido/skills --skill='*' -g
 ```
 
 Learn more about the CLI usage at [skills](https://github.com/vercel-labs/skills).


### PR DESCRIPTION
Fixes #3

`pnpx` has been deprecated in favor of `pnpm dlx`. Updated the README install commands accordingly.

Before:
```bash
pnpx skills add caido/skills --skill='*'
pnpx skills add caido/skills --skill='*' -g
```

After:
```bash
pnpm dlx skills add caido/skills --skill='*'
pnpm dlx skills add caido/skills --skill='*' -g
```

Verified working locally.