### PR TITLE
fix(caido-mode): start with cached access token when PAT is absent

### DIFF
--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -64,7 +64,7 @@ npx tsx ~/.claude/skills/caido-mode/caido-client.ts auth-status
 
 The SDK uses a device code flow internally — the PAT auto-approves it and receives an access token + refresh token. A custom `SecretsTokenCache` (implementing the SDK's `TokenCache` interface) persists these tokens to secrets.json so they survive across CLI invocations.
 
-Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → error with setup instructions
+Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → unexpired `secrets.json` `cachedToken` → error with setup instructions
 
 ## CLI Tool
 

--- a/skills/caido-mode/lib/client.ts
+++ b/skills/caido-mode/lib/client.ts
@@ -7,9 +7,35 @@ import { join, dirname } from "path";
 
 const SECRETS_PATH = join(homedir(), ".claude", "config", "secrets.json");
 
+export type AuthMode = "pat" | "cached-token";
+
 export interface CaidoConfig {
   url: string;
-  pat: string;
+  pat: string;         // empty string when authMode === "cached-token"
+  authMode: AuthMode;
+}
+
+export interface CaidoSecrets {
+  url?: string;
+  pat?: string;
+  cachedToken?: { accessToken?: string; expiresAt?: string };
+}
+
+function readCaidoSecrets(): CaidoSecrets {
+  if (!existsSync(SECRETS_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(SECRETS_PATH, "utf-8"));
+    return (parsed?.caido ?? {}) as CaidoSecrets;
+  } catch {
+    return {};
+  }
+}
+
+export function isCachedTokenValid(secrets: CaidoSecrets): boolean {
+  const token = secrets.cachedToken;
+  if (!token?.accessToken || !token.expiresAt) return false;
+  const exp = Date.parse(token.expiresAt);
+  return Number.isFinite(exp) && exp > Date.now();
 }
 
 /**
@@ -65,25 +91,33 @@ export class SecretsTokenCache implements TokenCache {
 
 export function loadConfig(): CaidoConfig {
   const url = process.env.CAIDO_URL || "http://localhost:8080";
-  const pat = process.env.CAIDO_PAT;
+  const envPat = process.env.CAIDO_PAT;
 
-  if (pat) return { url, pat };
+  if (envPat) return { url, pat: envPat, authMode: "pat" };
 
-  if (existsSync(SECRETS_PATH)) {
-    try {
-      const secrets = JSON.parse(readFileSync(SECRETS_PATH, "utf-8"));
-      if (secrets.caido?.pat) {
-        return { url: secrets.caido.url || url, pat: secrets.caido.pat };
-      }
-    } catch {}
+  const secrets = readCaidoSecrets();
+  const resolvedUrl = secrets.url || url;
+
+  if (secrets.pat) {
+    return { url: resolvedUrl, pat: secrets.pat, authMode: "pat" };
   }
 
-  console.error("Error: No Caido PAT found.\n");
-  console.error("Setup:");
-  console.error("  1. Open Caido → Settings → Developer → Personal Access Tokens");
-  console.error("  2. Create a token");
-  console.error("  3. Run: npx tsx caido-client.ts setup <token>");
-  console.error("  Or set env var: export CAIDO_PAT=<token>");
+  const tokenValid = isCachedTokenValid(secrets);
+  if (tokenValid) {
+    return { url: resolvedUrl, pat: "", authMode: "cached-token" };
+  }
+
+  const hasExpired = !!secrets.cachedToken?.accessToken;
+  if (hasExpired) {
+    console.error(`Error: Cached access token expired at ${secrets.cachedToken?.expiresAt}.`);
+    console.error("Re-run: npx tsx caido-client.ts setup <pat>");
+  } else {
+    console.error("Error: No Caido auth found.");
+    console.error("  - No PAT in env (CAIDO_PAT) or secrets.json");
+    console.error("  - No unexpired cached token in secrets.json");
+    console.error("");
+    console.error("Setup: npx tsx caido-client.ts setup <pat>");
+  }
   process.exit(1);
 }
 

--- a/skills/caido-mode/lib/commands/info.ts
+++ b/skills/caido-mode/lib/commands/info.ts
@@ -3,7 +3,7 @@
 import { Client } from "@caido/sdk-client";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { getClient, loadConfig, SecretsTokenCache, SECRETS_PATH } from "../client";
+import { getClient, loadConfig, SecretsTokenCache, SECRETS_PATH, isCachedTokenValid, type CaidoSecrets } from "../client";
 import { PLUGIN_PACKAGES_QUERY } from "../graphql";
 
 export async function cmdViewer() {
@@ -69,6 +69,16 @@ export async function cmdSetup(pat: string, url: string) {
 
 export async function cmdAuthStatus() {
   const config = loadConfig();
+
+  const rawSecrets = existsSync(SECRETS_PATH)
+    ? (() => { try { return JSON.parse(readFileSync(SECRETS_PATH, "utf-8")); } catch { return {}; } })()
+    : {};
+  const caidoSecrets: CaidoSecrets = (rawSecrets?.caido ?? {}) as CaidoSecrets;
+
+  const cachedExpiresAt: string | null = caidoSecrets.cachedToken?.expiresAt ?? null;
+  const cachedTokenValid = isCachedTokenValid(caidoSecrets);
+  const hasPat = !!caidoSecrets.pat || !!process.env.CAIDO_PAT;
+
   const statusCache = new SecretsTokenCache();
   const client = new Client({
     url: config.url,
@@ -81,15 +91,23 @@ export async function cmdAuthStatus() {
     const health = await client.health();
     console.log(JSON.stringify({
       authenticated: true,
+      authMode: config.authMode,
+      hasPat,
+      cachedTokenExpiresAt: cachedExpiresAt,
+      cachedTokenValid,
+      url: config.url,
       user: viewer,
       health,
-      url: config.url,
     }, null, 2));
   } catch (err: any) {
     console.log(JSON.stringify({
       authenticated: false,
-      error: err.message,
+      authMode: config.authMode,
+      hasPat,
+      cachedTokenExpiresAt: cachedExpiresAt,
+      cachedTokenValid,
       url: config.url,
+      error: err.message,
     }, null, 2));
   }
 }


### PR DESCRIPTION
## Motivation

`loadConfig()` in `lib/client.ts` rejects any startup where `secrets.json` has no `pat`, even when a valid unexpired `cachedToken` is present. Users who rotate their PAT through the Caido UI end up with `cachedToken`-only secrets and the CLI becomes unusable until they re-run `setup`.

The existing `SecretsTokenCache` already hands the cached access token to the SDK before any device-code exchange, so a PAT is not strictly needed at that point — the current error is a config-resolver false negative.

Discovered while testing against PortSwigger's XSS lab at `/web-security/cross-site-scripting/contexts/lab-javascript-url-some-characters-blocked`.

## Change

1. `loadConfig()` resolves auth in three tiers: `CAIDO_PAT` env, `secrets.caido.pat`, then an unexpired `secrets.caido.cachedToken`. An empty-string PAT is passed to the SDK in the third tier; the `TokenCache.load()` callback supplies the actual access token.
2. `cmdAuthStatus` now reports `authMode`, `hasPat`, `cachedTokenExpiresAt`, `cachedTokenValid` alongside the existing connect check.
3. Expired cached tokens emit a dedicated "expired" error pointing at `setup`.

No SDK calls or command dispatch change.

## Smoke test

Against a real Caido 0.56.0 instance with a PAT-less `secrets.json`:

```bash
npx tsx caido-client.ts auth-status | jq '{authMode, cachedTokenValid}'
# => {"authMode":"cached-token","cachedTokenValid":true}

# Expired token -> dedicated error
jq '.caido.cachedToken.expiresAt = "2020-01-01T00:00:00Z"' ~/.claude/config/secrets.json | sponge ~/.claude/config/secrets.json
npx tsx caido-client.ts auth-status 2>&1 | head -2
# => Error: Cached access token expired at 2020-01-01T00:00:00Z.
# => Re-run: npx tsx caido-client.ts setup <pat>

# No auth of any kind -> improved message
jq 'del(.caido.cachedToken)' ~/.claude/config/secrets.json | sponge ~/.claude/config/secrets.json
npx tsx caido-client.ts auth-status 2>&1 | head -5
# => Error: No Caido auth found.
# =>   - No PAT in env (CAIDO_PAT) or secrets.json
# =>   - No unexpired cached token in secrets.json
# =>
# => Setup: npx tsx caido-client.ts setup <pat>
```

## Risks

If a future `@caido/sdk-client` validates a non-empty PAT before consulting `TokenCache`, the third tier breaks. Detection: the smoke test above regresses on an SDK bump.

## Out of scope

A separate server-version compatibility issue — SDK 0.2.0 declares `$filter: HTTPQLInput` on request-list operations, which Caido 0.45.x rejects because `HTTPQL` is a scalar there. Verified locally that upgrading Caido to 0.56.0 resolves the incompatibility without any skill change; no compat PR is needed.
