### PR TITLE
feat(caido-mode): converge replay workflow features

### DIFF
--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -15,8 +15,9 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 | Category | Commands |
 |----------|----------|
 | **HTTP History** | `search`, `recent`, `get`, `get-response`, `export-curl` |
-| **Edit & Replay** | `edit`, `replay`, `send-raw` |
-| **Sessions** | `create-session`, `rename-session`, `replay-sessions`, `delete-sessions` |
+| **Edit & Replay** | `edit`, `replay`, `send-raw`, `edit-session` |
+| **Replay Tab Lookup** | `get-session`, `replay-entries`, `session-entries` |
+| **Sessions** | `create-session`, `rename-session`, `move-session`, `replay-sessions`, `delete-sessions` |
 | **Collections** | `replay-collections`, `create-collection`, `rename-collection`, `delete-collection` |
 | **Fuzzing** | `create-automate-session`, `fuzz` |
 | **Scopes** | `scopes`, `create-scope`, `update-scope`, `delete-scope` |
@@ -50,7 +51,7 @@ npx tsx caido-client.ts recent --limit 1
 export CAIDO_PAT=<your-pat>
 ```
 
-The `setup` command uses the SDK's device code flow (auto-approved by your PAT) to obtain an access token, then saves both the PAT and cached token to `~/.claude/config/secrets.json` via a custom `TokenCache` implementation. Subsequent runs load the cached token directly.
+The `setup` command uses the SDK's device code flow (auto-approved by your PAT) to obtain an access token, then saves both the PAT and cached token to `~/.claude/config/secrets.json` via a custom `TokenCache` implementation. Subsequent runs load the cached token directly, and a valid cached token can be used even when the PAT is absent.
 
 ## File Structure
 
@@ -63,7 +64,7 @@ lib/
   types.ts               # Shared types (OutputOpts)
   commands/
     requests.ts          # search, recent, get, get-response, export-curl
-    replay.ts            # replay, send-raw, edit, sessions, collections, automate, fuzz
+    replay.ts            # replay, send-raw, edit, replay-tab lookup, sessions, collections, automate, fuzz
     findings.ts          # findings, get-finding, create-finding, update-finding
     management.ts        # scopes, filters, environments, projects, hosted-files, tasks
     intercept.ts         # intercept-status, intercept-enable, intercept-disable
@@ -80,6 +81,7 @@ All commands output JSON. Run `npx tsx caido-client.ts --help` for the complete 
 # Search with HTTPQL (Caido's query language)
 npx tsx caido-client.ts search 'req.method.eq:"POST" AND resp.code.eq:200'
 npx tsx caido-client.ts search 'req.host.cont:"api"' --limit 50
+npx tsx caido-client.ts search 'req.host.cont:"api"' --desc --limit 10
 
 # Get recent requests
 npx tsx caido-client.ts recent --limit 10
@@ -108,7 +110,36 @@ npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"
 
 # Find/replace text anywhere in the request
 npx tsx caido-client.ts edit <id> --replace "user123:::user456"
+
+# Reuse a replay session while iterating
+npx tsx caido-client.ts edit <id> --path /api/user/456 --session <session-id> --compact
 ```
+
+`edit`, `replay`, and `send-raw` support connection overrides for virtual-host and upstream routing tests: `--sni`, `--connect-host`, `--connect-port`, `--connect-tls`, and `--connect-no-tls`.
+
+### Replay Tab Lookup
+
+Work directly from an existing Caido replay tab/session.
+
+```bash
+npx tsx caido-client.ts get-session <session-id-or-name> --compact
+npx tsx caido-client.ts replay-entries <session-id-or-name> --limit 20
+npx tsx caido-client.ts replay-entries <session-id-or-name> --raw --compact
+npx tsx caido-client.ts edit-session <session-id-or-name> --body '{"test":true}' --compact
+```
+
+`session-entries` is accepted as an alias for `replay-entries`.
+
+### Raw Replay
+
+```bash
+npx tsx caido-client.ts send-raw --host example.com --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+npx tsx caido-client.ts send-raw --host example.com --raw @request.txt --name "G /"
+cat request.txt | npx tsx caido-client.ts send-raw --host example.com --raw -
+npx tsx caido-client.ts replay <id> --connect-host 10.0.0.5 --connect-port 8443 --sni example.com
+```
+
+`--raw` accepts a string with C-style escapes, `@file`, or `-` for stdin.
 
 ### Export to curl
 
@@ -160,7 +191,9 @@ npx tsx caido-client.ts delete-env <id>
 
 ```bash
 npx tsx caido-client.ts create-session <request-id>
+npx tsx caido-client.ts create-session <request-id> --collection <collection-id>
 npx tsx caido-client.ts rename-session <session-id> "idor-user-profile"
+npx tsx caido-client.ts move-session <session-id> <collection-id>
 npx tsx caido-client.ts replay-sessions
 npx tsx caido-client.ts delete-sessions <id1>,<id2>
 
@@ -226,7 +259,7 @@ preset:"My Filter"                            # Use saved filter preset
 
 ## Architecture
 
-Built on `@caido/sdk-client` v0.1.4+. Multi-file architecture with clean separation:
+Built on `@caido/sdk-client` v0.2.0+. Multi-file architecture with clean separation:
 
 - **High-level SDK methods** for most features (requests, replay, findings, scopes, filters, environments, projects, hosted files, tasks, user)
 - **`client.graphql.query()`/`mutation()`** with `gql` tagged templates for features not yet in SDK (intercept, plugins, automate/fuzz)

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -52,7 +52,7 @@ npx tsx ~/.claude/skills/caido-mode/caido-client.ts setup <pat> http://192.168.1
 export CAIDO_PAT=caido_xxxxx
 ```
 
-The `setup` command validates the PAT via the SDK (which exchanges it for an access token), then saves both the PAT and the cached access token to `~/.claude/config/secrets.json`. Subsequent runs load the cached token directly, skipping the PAT exchange.
+The `setup` command validates the PAT via the SDK (which exchanges it for an access token), then saves both the PAT and the cached access token to `~/.claude/config/secrets.json`. Subsequent runs load the cached token directly, and a valid cached token can be used even when the PAT is absent.
 
 ### Check Status
 
@@ -64,7 +64,7 @@ npx tsx ~/.claude/skills/caido-mode/caido-client.ts auth-status
 
 The SDK uses a device code flow internally — the PAT auto-approves it and receives an access token + refresh token. A custom `SecretsTokenCache` (implementing the SDK's `TokenCache` interface) persists these tokens to secrets.json so they survive across CLI invocations.
 
-Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → error with setup instructions
+Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → valid cached access token → error with setup instructions
 
 ## CLI Tool
 
@@ -79,6 +79,7 @@ Located at `~/.claude/skills/caido-mode/caido-client.ts`. All commands output JS
 ```bash
 npx tsx caido-client.ts search 'req.method.eq:"POST" AND resp.code.eq:200'
 npx tsx caido-client.ts search 'req.host.cont:"api"' --limit 50
+npx tsx caido-client.ts search 'req.host.cont:"api"' --desc --limit 10
 npx tsx caido-client.ts search 'req.path.cont:"/admin"' --ids-only
 npx tsx caido-client.ts search 'resp.raw.cont:"password"' --after <cursor>
 ```
@@ -119,6 +120,9 @@ npx tsx caido-client.ts edit <id> --replace "user123:::user456"
 
 # Combine multiple edits
 npx tsx caido-client.ts edit <id> --method PUT --path /api/admin --body '{"role":"admin"}' --compact
+
+# Reuse an existing replay tab/session for repeated probes
+npx tsx caido-client.ts edit <id> --path /api/user/1001 --session <session-id> --compact
 ```
 
 | Option | Description |
@@ -129,6 +133,12 @@ npx tsx caido-client.ts edit <id> --method PUT --path /api/admin --body '{"role"
 | `--remove-header <Name>` | Remove a header (repeatable) |
 | `--body <content>` | Set request body (auto-updates Content-Length) |
 | `--replace <from>:::<to>` | Find/replace text anywhere in request (repeatable) |
+| `--session <id>` | Reuse an existing replay session instead of creating a new tab |
+| `--collection <id>` | Put a newly created replay session in a collection |
+| `--sni <host>` | Override TLS SNI |
+| `--connect-host <host>` | Connect to a different host while preserving the HTTP request |
+| `--connect-port <port>` | Connect to a different port |
+| `--connect-tls` / `--connect-no-tls` | Force TLS/plaintext for the connection |
 
 ### replay / send-raw - Send requests
 
@@ -141,7 +151,14 @@ npx tsx caido-client.ts replay <id> --raw "GET /modified HTTP/1.1\r\nHost: examp
 
 # Send completely custom request
 npx tsx caido-client.ts send-raw --host example.com --port 443 --tls --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+npx tsx caido-client.ts send-raw --host example.com --raw @request.txt --name "G /"
+cat request.txt | npx tsx caido-client.ts send-raw --host example.com --raw -
+
+# Connect elsewhere while preserving the request Host/SNI you need
+npx tsx caido-client.ts replay <id> --connect-host 10.0.0.5 --connect-port 8443 --sni example.com
 ```
+
+`--raw` accepts a string with `\r\n` escapes, `@file` to read from disk, or `-` to read from stdin.
 
 ### export-curl - Convert to curl for PoCs
 
@@ -153,6 +170,21 @@ Outputs a ready-to-use curl command with all headers and body.
 
 ---
 
+## Replay Tab Lookup
+
+Use these when a Caido replay tab is already open and you want to work from its active entry directly.
+
+```bash
+npx tsx caido-client.ts get-session <session-id-or-name> --compact
+npx tsx caido-client.ts replay-entries <session-id-or-name> --limit 20
+npx tsx caido-client.ts replay-entries <session-id-or-name> --raw --compact
+npx tsx caido-client.ts edit-session <session-id-or-name> --body '{"test":true}' --compact
+```
+
+`session-entries` is accepted as an alias for `replay-entries`.
+
+---
+
 ## Replay Sessions & Collections
 
 ### Sessions
@@ -160,6 +192,7 @@ Outputs a ready-to-use curl command with all headers and body.
 ```bash
 # Create replay session from an existing request
 npx tsx caido-client.ts create-session <request-id>
+npx tsx caido-client.ts create-session <request-id> --collection <collection-id>
 
 # ALWAYS rename sessions for easy identification in Caido UI
 npx tsx caido-client.ts rename-session <session-id> "idor-user-profile"
@@ -167,6 +200,9 @@ npx tsx caido-client.ts rename-session <session-id> "idor-user-profile"
 # List all replay sessions
 npx tsx caido-client.ts replay-sessions
 npx tsx caido-client.ts replay-sessions --limit 50
+
+# Move sessions between collections
+npx tsx caido-client.ts move-session <session-id> <collection-id>
 
 # Delete replay sessions
 npx tsx caido-client.ts delete-sessions <session-id-1>,<session-id-2>
@@ -468,7 +504,7 @@ req.path.ncont:"/health" AND req.path.ncont:"/metrics"
 
 ## SDK Architecture
 
-This CLI is built on `@caido/sdk-client` v0.1.4+, using a clean multi-file architecture:
+This CLI is built on `@caido/sdk-client` v0.2.0+, using a clean multi-file architecture:
 
 ```
 caido-client.ts          # CLI entry point — arg parsing + command dispatch
@@ -479,7 +515,7 @@ lib/
   types.ts               # Shared types (OutputOpts)
   commands/
     requests.ts          # search, recent, get, get-response, export-curl
-    replay.ts            # replay, send-raw, edit, sessions, collections, automate, fuzz
+    replay.ts            # replay, send-raw, edit, replay-tab lookup, sessions, collections, automate, fuzz
     findings.ts          # findings, get-finding, create-finding, update-finding
     management.ts        # scopes, filters, environments, projects, hosted-files, tasks
     intercept.ts         # intercept-status, intercept-enable, intercept-disable

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -9,13 +9,40 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 
 // Commands
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
-import { cmdReplay, cmdSendRaw, cmdEdit, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import { cmdReplay, cmdSendRaw, cmdEdit, cmdGetSession, cmdReplayEntries, cmdEditSession, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdMoveSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import type { ConnectionOverrides } from "./lib/commands/replay";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
 import { cmdViewer, cmdPlugins, cmdHealth, cmdSetup, cmdAuthStatus } from "./lib/commands/info";
 
 const DEBUG = process.env.DEBUG === "1";
+
+function parseConnectionOverrides(args: string[], startIdx: number): ConnectionOverrides {
+  const overrides: ConnectionOverrides = {};
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--sni" && args[i + 1]) { overrides.sni = args[i + 1]; i++; }
+    else if (args[i] === "--connect-host" && args[i + 1]) { overrides.connectHost = args[i + 1]; i++; }
+    else if (args[i] === "--connect-port" && args[i + 1]) { overrides.connectPort = parseInt(args[i + 1], 10); i++; }
+    else if (args[i] === "--connect-tls") { overrides.connectTls = true; }
+    else if (args[i] === "--connect-no-tls") { overrides.connectTls = false; }
+  }
+  return overrides;
+}
+
+function parseCollectionId(args: string[], startIdx: number): string | undefined {
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--collection" && args[i + 1]) return args[i + 1];
+  }
+  return undefined;
+}
+
+function parseSessionName(args: string[], startIdx: number): string | undefined {
+  for (let i = startIdx; i < args.length; i++) {
+    if (args[i] === "--name" && args[i + 1]) return args[i + 1];
+  }
+  return undefined;
+}
 
 function printUsage() {
   console.log(`
@@ -32,6 +59,7 @@ Usage:
     --limit <n>                Max results (default: 20)
     --after <cursor>           Pagination cursor
     --ids-only                 Output only request IDs
+    --desc / --latest          Sort newest first by request ID
 
   recent                       Get recent requests
     --limit <n>                Max results (default: 20)
@@ -41,13 +69,26 @@ Usage:
   get-response <request-id>    Get just the response for a request
 
   replay <request-id>          Replay a request (blocks until response)
-    --raw <raw-request>        Override with custom raw request
+    --raw <str|@file|->        Override with custom raw request
+    --collection <id>          Add session to this collection
+    --sni <hostname>           TLS Server Name Indication override
+    --connect-host <host>      Connect to a different host
+    --connect-port <port>      Connect to a different port
+    --connect-tls              Force TLS on override connection
+    --connect-no-tls           Force plain HTTP on override connection
 
   send-raw                     Send a custom raw request
     --host <hostname>          Target host (required)
     --port <port>              Target port (default: 443)
     --tls / --no-tls           Use TLS (default: true)
-    --raw <raw-request>        Raw HTTP request (required)
+    --raw <str|@file|->        Raw HTTP request (required)
+    --collection <id>          Add session to this collection
+    --name <session-name>      Rename the replay session
+    --sni <hostname>           TLS Server Name Indication override
+    --connect-host <host>      Connect to a different host
+    --connect-port <port>      Connect to a different port
+    --connect-tls              Force TLS on override connection
+    --connect-no-tls           Force plain HTTP on override connection
 
   edit <request-id>            Edit and replay a request (keeps cookies/auth)
     --method <METHOD>          Change HTTP method
@@ -56,15 +97,40 @@ Usage:
     --remove-header <name>     Remove header (repeatable)
     --body <body>              Set request body
     --replace <from>:::<to>    Replace text in request (repeatable)
+    --session <id>             Reuse an existing replay session
+    --collection <id>          Add new session to this collection
+    --sni <hostname>           TLS Server Name Indication override
+    --connect-host <host>      Connect to a different host
+    --connect-port <port>      Connect to a different port
+    --connect-tls              Force TLS on override connection
+    --connect-no-tls           Force plain HTTP on override connection
 
   export-curl <request-id>     Export request as curl command
+
+═══════════════════════════════════════════════
+ REPLAY TAB LOOKUP
+═══════════════════════════════════════════════
+
+  get-session <id-or-name>     Get a replay session and active entry
+  replay-entries <id-or-name>  List request history within a replay session
+    --limit <n>                Max results (default: 20)
+    --raw                      Include raw replay/request/response data
+  edit-session <id-or-name>    Edit and send from a session's active entry
+    --method <METHOD>          Change HTTP method
+    --path <path>              Change request path
+    --set-header <N:V>         Set header (repeatable)
+    --remove-header <name>     Remove header (repeatable)
+    --body <body>              Set request body
+    --replace <from>:::<to>    Replace text in request (repeatable)
 
 ═══════════════════════════════════════════════
  REPLAY SESSIONS & COLLECTIONS
 ═══════════════════════════════════════════════
 
   create-session <request-id>  Create a replay session from a request
+    --collection <id>          Add session to this collection
   rename-session <id> <name>   Rename a replay session
+  move-session <id> <coll-id>  Move a replay session to a collection
   replay-sessions              List replay sessions
     --limit <n>                Max results (default: 20)
   delete-sessions <id,id,...>  Delete replay sessions
@@ -198,8 +264,11 @@ Usage:
     export CAIDO_URL=http://localhost:8080
 
 Examples:
-  npx tsx caido-client.ts search 'req.method.eq:"POST"' --limit 50
-  npx tsx caido-client.ts edit 12345 --path /api/admin --method POST
+  npx tsx caido-client.ts search 'req.method.eq:"POST"' --desc --limit 50
+  npx tsx caido-client.ts edit 12345 --path /api/admin --method POST --session 412
+  npx tsx caido-client.ts edit-session 412 --body '{"test":true}' --compact
+  npx tsx caido-client.ts send-raw --host target.com --raw @request.txt --name "Po /api/check"
+  cat request.txt | npx tsx caido-client.ts send-raw --host target.com --raw -
   npx tsx caido-client.ts create-finding 12345 --title "IDOR" --reporter "rez0"
   npx tsx caido-client.ts create-scope "Target" --allow "*.example.com"
   npx tsx caido-client.ts replay-sessions --limit 10
@@ -224,12 +293,14 @@ async function main() {
       let limit = 20;
       let after: string | undefined;
       let idsOnly = false;
+      let desc = false;
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
         else if (args[i] === "--after" && args[i + 1]) { after = args[i + 1]; i++; }
         else if (args[i] === "--ids-only") { idsOnly = true; }
+        else if (args[i] === "--desc" || args[i] === "--latest") { desc = true; }
       }
-      await cmdSearch(filter, limit, after, idsOnly);
+      await cmdSearch(filter, limit, after, idsOnly, desc);
       break;
     }
 
@@ -260,7 +331,13 @@ async function main() {
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--raw" && args[i + 1]) { rawOverride = args[i + 1]; i++; }
       }
-      await cmdReplay(args[1], rawOverride, parseOutputOpts(args, 2));
+      await cmdReplay(
+        args[1],
+        rawOverride,
+        parseOutputOpts(args, 2),
+        parseConnectionOverrides(args, 2),
+        parseCollectionId(args, 2),
+      );
       break;
     }
 
@@ -277,13 +354,22 @@ async function main() {
         console.error("Error: --host and --raw are required");
         process.exit(1);
       }
-      await cmdSendRaw(host, port, tls, raw, parseOutputOpts(args, 1));
+      await cmdSendRaw(
+        host,
+        port,
+        tls,
+        raw,
+        parseOutputOpts(args, 1),
+        parseConnectionOverrides(args, 1),
+        parseCollectionId(args, 1),
+        parseSessionName(args, 1),
+      );
       break;
     }
 
     case "edit": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
-      let method: string | undefined, path: string | undefined, body: string | undefined;
+      let method: string | undefined, path: string | undefined, body: string | undefined, sessionId: string | undefined;
       const setHeaders: string[] = [], removeHeaders: string[] = [], replacements: string[] = [];
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--method" && args[i + 1]) { method = args[i + 1]; i++; }
@@ -292,8 +378,15 @@ async function main() {
         else if (args[i] === "--set-header" && args[i + 1]) { setHeaders.push(args[i + 1]); i++; }
         else if (args[i] === "--remove-header" && args[i + 1]) { removeHeaders.push(args[i + 1]); i++; }
         else if (args[i] === "--replace" && args[i + 1]) { replacements.push(args[i + 1]); i++; }
+        else if (args[i] === "--session" && args[i + 1]) { sessionId = args[i + 1]; i++; }
       }
-      await cmdEdit(args[1], { method, path, body, setHeaders, removeHeaders, replacements }, parseOutputOpts(args, 2));
+      await cmdEdit(
+        args[1],
+        { method, path, body, setHeaders, removeHeaders, replacements, sessionId },
+        parseOutputOpts(args, 2),
+        parseConnectionOverrides(args, 2),
+        parseCollectionId(args, 2),
+      );
       break;
     }
 
@@ -303,16 +396,63 @@ async function main() {
       break;
     }
 
+    // ── Replay Tab Lookup ──
+    case "get-session": {
+      if (!args[1]) { console.error("Error: session id or name required"); process.exit(1); }
+      await cmdGetSession(args[1], parseOutputOpts(args, 2));
+      break;
+    }
+
+    case "replay-entries":
+    case "session-entries": {
+      if (!args[1]) { console.error("Error: session id or name required"); process.exit(1); }
+      let limit = 20;
+      let includeRaw = false;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--raw") { includeRaw = true; }
+      }
+      await cmdReplayEntries(args[1], limit, parseOutputOpts(args, 2), includeRaw);
+      break;
+    }
+
+    case "edit-session": {
+      if (!args[1]) { console.error("Error: session id or name required"); process.exit(1); }
+      let esMethod: string | undefined, esPath: string | undefined, esBody: string | undefined;
+      const esSetHeaders: string[] = [], esRemoveHeaders: string[] = [], esReplacements: string[] = [];
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--method" && args[i + 1]) { esMethod = args[i + 1]; i++; }
+        else if (args[i] === "--path" && args[i + 1]) { esPath = args[i + 1]; i++; }
+        else if (args[i] === "--body" && args[i + 1]) { esBody = args[i + 1]; i++; }
+        else if (args[i] === "--set-header" && args[i + 1]) { esSetHeaders.push(args[i + 1]); i++; }
+        else if (args[i] === "--remove-header" && args[i + 1]) { esRemoveHeaders.push(args[i + 1]); i++; }
+        else if (args[i] === "--replace" && args[i + 1]) { esReplacements.push(args[i + 1]); i++; }
+      }
+      await cmdEditSession(
+        args[1],
+        { method: esMethod, path: esPath, body: esBody, setHeaders: esSetHeaders, removeHeaders: esRemoveHeaders, replacements: esReplacements },
+        parseOutputOpts(args, 2),
+        parseConnectionOverrides(args, 2),
+      );
+      break;
+    }
+
     // ── Replay Sessions ──
     case "create-session": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
-      await cmdCreateSession(args[1]);
+      await cmdCreateSession(args[1], parseCollectionId(args, 2));
       break;
     }
 
     case "rename-session": {
       if (!args[1] || !args[2]) { console.error("Error: session-id and name required"); process.exit(1); }
       await cmdRenameSession(args[1], args[2]);
+      break;
+    }
+
+    case "move-session": {
+      if (!args[1] || !args[2]) { console.error("Error: session-id and collection-id required"); process.exit(1); }
+      await cmdMoveSession(args[1], args[2]);
       break;
     }
 

--- a/skills/caido-mode/lib/client.ts
+++ b/skills/caido-mode/lib/client.ts
@@ -7,9 +7,35 @@ import { join, dirname } from "path";
 
 const SECRETS_PATH = join(homedir(), ".claude", "config", "secrets.json");
 
+export type AuthMode = "pat" | "cached-token";
+
 export interface CaidoConfig {
   url: string;
-  pat: string;
+  pat: string;         // empty string when authMode === "cached-token"
+  authMode: AuthMode;
+}
+
+export interface CaidoSecrets {
+  url?: string;
+  pat?: string;
+  cachedToken?: { accessToken?: string; expiresAt?: string };
+}
+
+function readCaidoSecrets(): CaidoSecrets {
+  if (!existsSync(SECRETS_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(SECRETS_PATH, "utf-8"));
+    return (parsed?.caido ?? {}) as CaidoSecrets;
+  } catch {
+    return {};
+  }
+}
+
+export function isCachedTokenValid(secrets: CaidoSecrets): boolean {
+  const token = secrets.cachedToken;
+  if (!token?.accessToken || !token.expiresAt) return false;
+  const exp = Date.parse(token.expiresAt);
+  return Number.isFinite(exp) && exp > Date.now();
 }
 
 /**
@@ -65,25 +91,33 @@ export class SecretsTokenCache implements TokenCache {
 
 export function loadConfig(): CaidoConfig {
   const url = process.env.CAIDO_URL || "http://localhost:8080";
-  const pat = process.env.CAIDO_PAT;
+  const envPat = process.env.CAIDO_PAT;
 
-  if (pat) return { url, pat };
+  if (envPat) return { url, pat: envPat, authMode: "pat" };
 
-  if (existsSync(SECRETS_PATH)) {
-    try {
-      const secrets = JSON.parse(readFileSync(SECRETS_PATH, "utf-8"));
-      if (secrets.caido?.pat) {
-        return { url: secrets.caido.url || url, pat: secrets.caido.pat };
-      }
-    } catch {}
+  const secrets = readCaidoSecrets();
+  const resolvedUrl = secrets.url || url;
+
+  if (secrets.pat) {
+    return { url: resolvedUrl, pat: secrets.pat, authMode: "pat" };
   }
 
-  console.error("Error: No Caido PAT found.\n");
-  console.error("Setup:");
-  console.error("  1. Open Caido → Settings → Developer → Personal Access Tokens");
-  console.error("  2. Create a token");
-  console.error("  3. Run: npx tsx caido-client.ts setup <token>");
-  console.error("  Or set env var: export CAIDO_PAT=<token>");
+  const tokenValid = isCachedTokenValid(secrets);
+  if (tokenValid) {
+    return { url: resolvedUrl, pat: "", authMode: "cached-token" };
+  }
+
+  const hasExpired = !!secrets.cachedToken?.accessToken;
+  if (hasExpired) {
+    console.error(`Error: Cached access token expired at ${secrets.cachedToken?.expiresAt}.`);
+    console.error("Re-run: npx tsx caido-client.ts setup <pat>");
+  } else {
+    console.error("Error: No Caido auth found.");
+    console.error("  - No PAT in env (CAIDO_PAT) or secrets.json");
+    console.error("  - No unexpired cached token in secrets.json");
+    console.error("");
+    console.error("Setup: npx tsx caido-client.ts setup <pat>");
+  }
   process.exit(1);
 }
 

--- a/skills/caido-mode/lib/commands/info.ts
+++ b/skills/caido-mode/lib/commands/info.ts
@@ -3,7 +3,7 @@
 import { Client } from "@caido/sdk-client";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { getClient, loadConfig, SecretsTokenCache, SECRETS_PATH } from "../client";
+import { getClient, loadConfig, SecretsTokenCache, SECRETS_PATH, isCachedTokenValid, type CaidoSecrets } from "../client";
 import { PLUGIN_PACKAGES_QUERY } from "../graphql";
 
 export async function cmdViewer() {
@@ -69,6 +69,16 @@ export async function cmdSetup(pat: string, url: string) {
 
 export async function cmdAuthStatus() {
   const config = loadConfig();
+
+  const rawSecrets = existsSync(SECRETS_PATH)
+    ? (() => { try { return JSON.parse(readFileSync(SECRETS_PATH, "utf-8")); } catch { return {}; } })()
+    : {};
+  const caidoSecrets: CaidoSecrets = (rawSecrets?.caido ?? {}) as CaidoSecrets;
+
+  const cachedExpiresAt: string | null = caidoSecrets.cachedToken?.expiresAt ?? null;
+  const cachedTokenValid = isCachedTokenValid(caidoSecrets);
+  const hasPat = !!caidoSecrets.pat || !!process.env.CAIDO_PAT;
+
   const statusCache = new SecretsTokenCache();
   const client = new Client({
     url: config.url,
@@ -81,15 +91,23 @@ export async function cmdAuthStatus() {
     const health = await client.health();
     console.log(JSON.stringify({
       authenticated: true,
+      authMode: config.authMode,
+      hasPat,
+      cachedTokenExpiresAt: cachedExpiresAt,
+      cachedTokenValid,
+      url: config.url,
       user: viewer,
       health,
-      url: config.url,
     }, null, 2));
   } catch (err: any) {
     console.log(JSON.stringify({
       authenticated: false,
-      error: err.message,
+      authMode: config.authMode,
+      hasPat,
+      cachedTokenExpiresAt: cachedExpiresAt,
+      cachedTokenValid,
       url: config.url,
+      error: err.message,
     }, null, 2));
   }
 }

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -9,47 +9,156 @@ import {
   CREATE_REPLAY_SESSION_RAW,
 } from "../graphql";
 import type { OutputOpts } from "../types";
+import type { ConnectionInfoInput } from "@caido/sdk-client";
 
-// ── Replay ──
+export interface ConnectionOverrides {
+  sni?: string;
+  connectHost?: string;
+  connectPort?: number;
+  connectTls?: boolean;
+}
 
-export async function cmdReplay(requestId: string, rawOverride: string | undefined, opts: OutputOpts) {
-  const client = await getClient();
+interface RawEdits {
+  method?: string;
+  path?: string;
+  setHeaders: string[];
+  removeHeaders: string[];
+  body?: string;
+  replacements: string[];
+}
 
-  // Get the original request to extract connection info
-  const original = await client.request.get(requestId, { raw: true });
-  if (!original) {
-    console.error(`Request ${requestId} not found`);
-    process.exit(1);
+function buildConnection(host: string, port: number, isTLS: boolean, overrides?: ConnectionOverrides): ConnectionInfoInput {
+  const connection: ConnectionInfoInput = {
+    host: overrides?.connectHost ?? host,
+    port: overrides?.connectPort ?? port,
+    isTLS: overrides?.connectTls ?? isTLS,
+  };
+  if (overrides?.sni) connection.SNI = overrides.sni;
+  return connection;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function resolveRaw(raw: string): Promise<string> {
+  if (raw === "-") return readStdin();
+
+  if (raw.startsWith("@")) {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    return readFile(resolve(raw.slice(1)), "utf-8");
   }
 
-  // Create a temporary replay session
-  const session = await client.replay.sessions.create({
-    requestSource: { id: requestId },
-  });
+  return normalizeRaw(raw);
+}
 
-  const raw = rawOverride || decodeRaw(original.request.raw);
-  if (!raw) {
-    console.error("No raw data for this request");
-    process.exit(1);
+export function normalizeRaw(raw: string): string {
+  if (raw.includes("\r\n")) return raw;
+  return raw.replace(/\\([rnt\\])/g, (_, ch) => {
+    switch (ch) {
+      case "r": return "\r";
+      case "n": return "\n";
+      case "t": return "\t";
+      case "\\": return "\\";
+      default: return ch;
+    }
+  });
+}
+
+function applyRawEdits(raw: string, edits: RawEdits): string {
+  for (const rep of edits.replacements) {
+    const [from, to] = rep.split(":::");
+    if (from && to !== undefined) raw = raw.replaceAll(from, to);
   }
 
-  const result = await client.replay.send(session.id, {
-    raw,
-    connection: {
-      host: original.request.host,
-      port: original.request.port,
-      isTLS: original.request.isTls,
-    },
-  });
+  const lineEnd = raw.includes("\r\n") ? "\r\n" : "\n";
+  const separator = lineEnd + lineEnd;
+  const parts = raw.split(separator);
+  const headerBlock = parts[0];
+  let bodyPart = parts.slice(1).join(separator);
 
+  const headerLines = headerBlock.split(lineEnd);
+  let requestLine = headerLines[0];
+  let headers = headerLines.slice(1);
+
+  if (edits.method) {
+    const spaceIdx = requestLine.indexOf(" ");
+    if (spaceIdx > 0) requestLine = edits.method + requestLine.substring(spaceIdx);
+  }
+
+  if (edits.path) {
+    const firstSpace = requestLine.indexOf(" ");
+    const lastSpace = requestLine.lastIndexOf(" ");
+    if (firstSpace > 0 && lastSpace > firstSpace) {
+      requestLine = requestLine.substring(0, firstSpace + 1) + edits.path + requestLine.substring(lastSpace);
+    }
+  }
+
+  for (const name of edits.removeHeaders) {
+    headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
+  }
+
+  for (const header of edits.setHeaders) {
+    const colonIdx = header.indexOf(":");
+    if (colonIdx > 0) {
+      const name = header.substring(0, colonIdx).trim();
+      headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
+      headers.push(header.trim());
+    }
+  }
+
+  if (edits.body !== undefined) {
+    bodyPart = edits.body;
+    const clBytes = new TextEncoder().encode(bodyPart).length;
+    headers = headers.filter(h => !h.toLowerCase().startsWith("content-length:"));
+    headers.push(`Content-Length: ${clBytes}`);
+  }
+
+  return [requestLine, ...headers].join(lineEnd) + separator + bodyPart;
+}
+
+async function resolveSession(client: any, idOrName: string) {
+  try {
+    const byId = await client.replay.sessions.get(idOrName);
+    if (byId) return byId;
+  } catch {}
+
+  let after: string | undefined;
+  while (true) {
+    const page = after
+      ? await client.replay.sessions.list().after(after, 100)
+      : await client.replay.sessions.list().first(100);
+
+    for (const edge of page.edges) {
+      if (edge.node.name === idOrName) return edge.node;
+    }
+
+    if (!page.pageInfo.hasNextPage) break;
+    after = page.pageInfo.endCursor;
+  }
+
+  return undefined;
+}
+
+function buildReplayOutput(sessionId: string, result: any, opts: OutputOpts, modifiedRaw?: string) {
   const output: Record<string, any> = {
-    sessionId: session.id,
+    sessionId,
     status: result.status,
     error: result.error,
   };
 
+  if (modifiedRaw !== undefined && !opts.noRequest) {
+    output.modifiedRequest = formatHttpRaw(modifiedRaw, opts);
+  }
+
   if (result.entry) {
     output.entryId = result.entry.id;
+    if (result.entry.request) output.requestId = result.entry.request.id;
     if (result.entry.response) {
       output.response = {
         statusCode: result.entry.response.statusCode,
@@ -62,180 +171,266 @@ export async function cmdReplay(requestId: string, rawOverride: string | undefin
     }
   }
 
-  console.log(JSON.stringify(output, null, 2));
+  return output;
 }
 
-export async function cmdSendRaw(host: string, port: number, tls: boolean, raw: string, opts: OutputOpts) {
-  const client = await getClient();
-
-  // SDK 0.2.0's sessions.create doesn't base64-encode the raw source, but
-  // Caido 0.56+ types it as Blob. Issue the mutation ourselves with an
-  // encoded payload; replay.send below handles its own encoding correctly.
-  const createResult = await client.graphql.mutation(CREATE_REPLAY_SESSION_RAW, {
-    input: {
-      requestSource: {
-        raw: {
-          connectionInfo: { host, port, isTLS: tls },
-          raw: Buffer.from(raw).toString("base64"),
-        },
+async function createRawReplaySession(
+  client: any,
+  raw: string,
+  connection: ConnectionInfoInput,
+  collectionId?: string,
+) {
+  const input: Record<string, any> = {
+    requestSource: {
+      raw: {
+        connectionInfo: connection,
+        raw: Buffer.from(raw, "utf-8").toString("base64"),
       },
     },
-  });
-  const session = (createResult as any).createReplaySession.session;
-
-  const result = await client.replay.send(session.id, {
-    raw,
-    connection: { host, port, isTLS: tls },
-  });
-
-  const output: Record<string, any> = {
-    sessionId: session.id,
-    status: result.status,
-    error: result.error,
   };
+  if (collectionId) input.collectionId = collectionId;
 
-  if (result.entry?.response) {
-    output.response = {
-      statusCode: result.entry.response.statusCode,
-      roundtrip: result.entry.response.roundtripTime,
-      length: result.entry.response.length,
-    };
-    if (result.entry.response.raw) {
-      output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
-    }
-  }
-
-  console.log(JSON.stringify(output, null, 2));
+  const createResult = await client.graphql.mutation(CREATE_REPLAY_SESSION_RAW, { input });
+  return (createResult as any).createReplaySession.session;
 }
 
-// ── Edit ──
+// -- Replay --
 
-export async function cmdEdit(
+export async function cmdReplay(
   requestId: string,
-  edits: {
-    method?: string;
-    path?: string;
-    setHeaders: string[];
-    removeHeaders: string[];
-    body?: string;
-    replacements: string[];
-  },
+  rawOverride: string | undefined,
   opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
 ) {
   const client = await getClient();
   const original = await client.request.get(requestId, { raw: true });
-
   if (!original) {
     console.error(`Request ${requestId} not found`);
     process.exit(1);
   }
 
-  let raw = decodeRaw(original.request.raw);
+  const createOpts: any = { requestSource: { id: requestId } };
+  if (collectionId) createOpts.collectionId = collectionId;
+  const session = await client.replay.sessions.create(createOpts);
+
+  const raw = rawOverride ? await resolveRaw(rawOverride) : decodeRaw(original.request.raw);
   if (!raw) {
     console.error("No raw data for this request");
     process.exit(1);
   }
 
-  // Apply replacements
-  for (const rep of edits.replacements) {
-    const [from, to] = rep.split(":::");
-    if (from && to !== undefined) {
-      raw = raw.replaceAll(from, to);
-    }
+  const connection = buildConnection(
+    original.request.host,
+    original.request.port,
+    original.request.isTls,
+    overrides,
+  );
+
+  const result = await client.replay.send(session.id, { raw, connection });
+  console.log(JSON.stringify(buildReplayOutput(session.id, result, opts), null, 2));
+}
+
+export async function cmdSendRaw(
+  host: string,
+  port: number,
+  tls: boolean,
+  raw: string,
+  opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
+  sessionName?: string,
+) {
+  const client = await getClient();
+  raw = await resolveRaw(raw);
+
+  const connection = buildConnection(host, port, tls, overrides);
+  const session = await createRawReplaySession(client, raw, connection, collectionId);
+
+  if (sessionName) await client.replay.sessions.rename(session.id, sessionName);
+
+  const result = await client.replay.send(session.id, { raw, connection });
+  console.log(JSON.stringify(buildReplayOutput(session.id, result, opts), null, 2));
+}
+
+// -- Edit --
+
+export async function cmdEdit(
+  requestId: string,
+  edits: RawEdits & { sessionId?: string },
+  opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+  collectionId?: string,
+) {
+  const client = await getClient();
+  const original = await client.request.get(requestId, { raw: true });
+  if (!original) {
+    console.error(`Request ${requestId} not found`);
+    process.exit(1);
   }
 
-  // Parse request line and headers
-  const lineEnd = raw.indexOf("\r\n") >= 0 ? "\r\n" : "\n";
-  const parts = raw.split(lineEnd + lineEnd);
-  const headerBlock = parts[0];
-  let bodyPart = parts.slice(1).join(lineEnd + lineEnd);
-
-  const headerLines = headerBlock.split(lineEnd);
-  let requestLine = headerLines[0];
-  let headers = headerLines.slice(1);
-
-  // Modify method
-  if (edits.method) {
-    const spaceIdx = requestLine.indexOf(" ");
-    if (spaceIdx > 0) {
-      requestLine = edits.method + requestLine.substring(spaceIdx);
-    }
+  const raw = decodeRaw(original.request.raw);
+  if (!raw) {
+    console.error("No raw data for this request");
+    process.exit(1);
   }
 
-  // Modify path
-  if (edits.path) {
-    const firstSpace = requestLine.indexOf(" ");
-    const lastSpace = requestLine.lastIndexOf(" ");
-    if (firstSpace > 0 && lastSpace > firstSpace) {
-      requestLine = requestLine.substring(0, firstSpace + 1) + edits.path + requestLine.substring(lastSpace);
-    }
+  const modifiedRaw = applyRawEdits(raw, edits);
+  const session = edits.sessionId
+    ? { id: edits.sessionId }
+    : await client.replay.sessions.create({
+      requestSource: { id: requestId },
+      ...(collectionId ? { collectionId } : {}),
+    });
+
+  const connection = buildConnection(
+    original.request.host,
+    original.request.port,
+    original.request.isTls,
+    overrides,
+  );
+
+  const result = await client.replay.send(session.id, { raw: modifiedRaw, connection });
+  console.log(JSON.stringify(buildReplayOutput(session.id, result, opts, modifiedRaw), null, 2));
+}
+
+export async function cmdGetSession(sessionIdOrName: string, opts: OutputOpts) {
+  const client = await getClient();
+  const session = await resolveSession(client, sessionIdOrName);
+  if (!session) {
+    console.error(`Replay session "${sessionIdOrName}" not found`);
+    process.exit(1);
   }
-
-  // Remove headers
-  for (const name of edits.removeHeaders) {
-    headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
-  }
-
-  // Set headers
-  for (const header of edits.setHeaders) {
-    const colonIdx = header.indexOf(":");
-    if (colonIdx > 0) {
-      const name = header.substring(0, colonIdx).trim();
-      headers = headers.filter(h => !h.toLowerCase().startsWith(name.toLowerCase() + ":"));
-      headers.push(header.trim());
-    }
-  }
-
-  // Set body
-  if (edits.body !== undefined) {
-    bodyPart = edits.body;
-    // Update Content-Length
-    const clBytes = new TextEncoder().encode(bodyPart).length;
-    headers = headers.filter(h => !h.toLowerCase().startsWith("content-length:"));
-    headers.push(`Content-Length: ${clBytes}`);
-  }
-
-  const modifiedRaw = [requestLine, ...headers].join(lineEnd) + lineEnd + lineEnd + bodyPart;
-
-  // Create session and send
-  const session = await client.replay.sessions.create({
-    requestSource: { id: requestId },
-  });
-
-  const result = await client.replay.send(session.id, {
-    raw: modifiedRaw,
-    connection: {
-      host: original.request.host,
-      port: original.request.port,
-      isTLS: original.request.isTls,
-    },
-  });
 
   const output: Record<string, any> = {
-    sessionId: session.id,
-    status: result.status,
-    error: result.error,
+    id: session.id,
+    name: session.name,
+    collectionId: session.collectionId,
+    activeEntryId: session.activeEntryId,
   };
 
-  if (!opts.noRequest) {
-    output.modifiedRequest = formatHttpRaw(modifiedRaw, opts);
-  }
-
-  if (result.entry?.response) {
-    output.response = {
-      statusCode: result.entry.response.statusCode,
-      roundtrip: result.entry.response.roundtripTime,
-      length: result.entry.response.length,
-    };
-    if (result.entry.response.raw) {
-      output.response.raw = formatHttpRaw(decodeRaw(result.entry.response.raw), opts);
-    }
+  if (session.activeEntryId) {
+    const entry = await client.replay.entries.get(session.activeEntryId);
+    if (entry) output.activeEntry = formatReplayEntry(entry, opts, true);
   }
 
   console.log(JSON.stringify(output, null, 2));
 }
 
-// ── Sessions ──
+export async function cmdReplayEntries(
+  sessionIdOrName: string,
+  limit: number,
+  opts: OutputOpts,
+  includeRaw: boolean,
+) {
+  const client = await getClient();
+  const session = await resolveSession(client, sessionIdOrName);
+  if (!session) {
+    console.error(`Replay session "${sessionIdOrName}" not found`);
+    process.exit(1);
+  }
+
+  const connection = await session.entries()
+    .includeRaw(includeRaw ? { request: true, response: true, replay: true } : false)
+    .first(limit);
+
+  const results = connection.edges.map((e: any) => formatReplayEntry(e.node, opts, includeRaw));
+
+  console.log(JSON.stringify({
+    sessionId: session.id,
+    sessionName: session.name,
+    activeEntryId: session.activeEntryId,
+    results,
+    count: results.length,
+  }, null, 2));
+}
+
+export async function cmdEditSession(
+  sessionIdOrName: string,
+  edits: RawEdits,
+  opts: OutputOpts,
+  overrides?: ConnectionOverrides,
+) {
+  const client = await getClient();
+  const session = await resolveSession(client, sessionIdOrName);
+  if (!session) {
+    console.error(`Replay session "${sessionIdOrName}" not found`);
+    process.exit(1);
+  }
+
+  if (!session.activeEntryId) {
+    console.error(`Session ${session.id} has no active entry`);
+    process.exit(1);
+  }
+
+  const entry = await client.replay.entries.get(session.activeEntryId);
+  if (!entry?.raw) {
+    console.error(`Could not get raw data for active entry ${session.activeEntryId}`);
+    process.exit(1);
+  }
+
+  const raw = decodeRaw(entry.raw);
+  if (!raw) {
+    console.error("No raw data for the active entry");
+    process.exit(1);
+  }
+
+  const modifiedRaw = applyRawEdits(raw, edits);
+  const connection = buildConnection(
+    entry.connection.host,
+    entry.connection.port,
+    entry.connection.isTLS,
+    overrides,
+  );
+
+  const result = await client.replay.send(session.id, { raw: modifiedRaw, connection });
+  console.log(JSON.stringify(buildReplayOutput(session.id, result, opts, modifiedRaw), null, 2));
+}
+
+function formatReplayEntry(entry: any, opts: OutputOpts, includeRaw: boolean) {
+  const output: Record<string, any> = {
+    id: entry.id,
+    sessionId: entry.sessionId,
+    createdAt: entry.createdAt,
+    error: entry.error,
+    connection: entry.connection ? {
+      host: entry.connection.host,
+      port: entry.connection.port,
+      isTLS: entry.connection.isTLS,
+      ...(entry.connection.SNI ? { SNI: entry.connection.SNI } : {}),
+    } : undefined,
+  };
+
+  if (entry.request) {
+    output.request = {
+      id: entry.request.id,
+      method: entry.request.method,
+      host: entry.request.host,
+      port: entry.request.port,
+      path: entry.request.path,
+      query: entry.request.query || undefined,
+      isTls: entry.request.isTls,
+    };
+  }
+
+  if (entry.response) {
+    output.response = {
+      statusCode: entry.response.statusCode,
+      roundtrip: entry.response.roundtripTime,
+      length: entry.response.length,
+    };
+  }
+
+  if (includeRaw) {
+    if (entry.raw) output.raw = formatHttpRaw(decodeRaw(entry.raw), opts);
+    if (entry.request?.raw) output.request.raw = formatHttpRaw(decodeRaw(entry.request.raw), opts);
+    if (entry.response?.raw) output.response.raw = formatHttpRaw(decodeRaw(entry.response.raw), opts);
+  }
+
+  return output;
+}
+
+// -- Sessions --
 
 export async function cmdReplaySessions(limit: number) {
   const client = await getClient();
@@ -251,10 +446,11 @@ export async function cmdReplaySessions(limit: number) {
   console.log(JSON.stringify({ results, count: results.length }, null, 2));
 }
 
-export async function cmdCreateSession(requestId: string) {
+export async function cmdCreateSession(requestId: string, collectionId?: string) {
   const client = await getClient();
   const session = await client.replay.sessions.create({
     requestSource: { id: requestId },
+    ...(collectionId ? { collectionId } : {}),
   });
   console.log(JSON.stringify({
     id: session.id,
@@ -269,13 +465,24 @@ export async function cmdRenameSession(sessionId: string, name: string) {
   console.log(JSON.stringify({ id: sessionId, name, renamed: true }, null, 2));
 }
 
+export async function cmdMoveSession(sessionId: string, collectionId: string) {
+  const client = await getClient();
+  const session = await client.replay.sessions.move(sessionId, collectionId);
+  console.log(JSON.stringify({
+    id: session.id,
+    name: session.name,
+    collectionId: session.collectionId,
+    moved: true,
+  }, null, 2));
+}
+
 export async function cmdDeleteSessions(ids: string[]) {
   const client = await getClient();
   await client.replay.sessions.delete(ids);
   console.log(JSON.stringify({ deleted: ids }, null, 2));
 }
 
-// ── Collections ──
+// -- Collections --
 
 export async function cmdReplayCollections(limit: number) {
   const client = await getClient();
@@ -307,7 +514,7 @@ export async function cmdDeleteCollection(collectionId: string) {
   console.log(JSON.stringify({ deleted: collectionId }, null, 2));
 }
 
-// ── Automate / Fuzz ──
+// -- Automate / Fuzz --
 
 export async function cmdCreateAutomateSession(requestId: string) {
   const client = await getClient();
@@ -320,7 +527,6 @@ export async function cmdCreateAutomateSession(requestId: string) {
 export async function cmdFuzz(sessionId: string, payloads: string[]) {
   const client = await getClient();
 
-  // Verify session exists and get its current state
   const check = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
   const session = (check as any).automateSession;
   if (!session) {
@@ -333,7 +539,6 @@ export async function cmdFuzz(sessionId: string, payloads: string[]) {
     sessionId,
   }, null, 2));
 
-  // Start fuzzing
   const startResult = await client.graphql.mutation(START_AUTOMATE_TASK, { automateSessionId: sessionId });
   const task = (startResult as any).startAutomateTask.automateTask;
 

--- a/skills/caido-mode/lib/commands/requests.ts
+++ b/skills/caido-mode/lib/commands/requests.ts
@@ -4,9 +4,10 @@ import { getClient } from "../client";
 import { decodeRaw, formatHttpRaw, rawToCurl } from "../output";
 import type { OutputOpts } from "../types";
 
-export async function cmdSearch(filter: string, limit: number, after?: string, idsOnly?: boolean) {
+export async function cmdSearch(filter: string, limit: number, after?: string, idsOnly?: boolean, desc?: boolean) {
   const client = await getClient();
   let builder = client.request.list().filter(filter).first(limit);
+  if (desc) builder = builder.descending("req", "id");
   if (after) builder = builder.after(after);
 
   const connection = await builder;


### PR DESCRIPTION
## Summary

Converges the useful pieces from the open caido-mode PRs onto current `main` in one clean branch:

- #4: `search --desc` / `--latest` for newest-first filtered history searches
- #6: `edit --session <id>` to reuse an existing replay tab while iterating
- #7: raw replay ergonomics, connection overrides, session naming, collection assignment, and `move-session`
- #8: replay tab lookup/editing via `get-session`, `replay-entries`, and `edit-session`
- #17: cached-token auth startup when a PAT is absent

## Cleanup while converging

- Kept current `main`'s `@caido/sdk-client@^0.2.0` and Caido 0.56+ GraphQL compatibility fixes.
- Kept upstream's manual `CREATE_REPLAY_SESSION_RAW` path for raw replay creation, and used `Buffer.from(...).toString("base64")` so non-Latin request bodies round-trip correctly.
- Factored raw request mutation into one helper used by both `edit` and `edit-session` instead of duplicating parser/edit logic.
- Made `replay-entries --raw` include replay/request/response raw data when requested.
- Treated `session-entries` as a compatibility alias for `replay-entries` rather than adding two separate concepts.
- Updated `README.md` and `SKILL.md` for the combined behavior.

## Test plan

- `npm install`
- `npx -y -p typescript -p @types/node tsc --noEmit --allowImportingTsExtensions --moduleResolution bundler --module esnext --target es2022 --types node --strict false caido-client.ts`
- `npx tsx caido-client.ts --help`
- `npx tsx -e 'import { normalizeRaw } from "./lib/commands/replay.ts"; const raw = normalizeRaw("POST / HTTP/1.1\\\\r\\\\nHost: x\\\\r\\\\n\\\\r\\\\n{\\\\\"name\\\\\":\\\\\"田中太郎\\\\\"}"); const encoded = Buffer.from(raw, "utf-8").toString("base64"); if (!raw.includes("\\r\\n\\r\\n")) throw new Error("CRLF normalization failed"); if (Buffer.from(encoded, "base64").toString("utf-8") !== raw) throw new Error("unicode base64 round trip failed"); console.log(JSON.stringify({ok:true, bytes: Buffer.byteLength(raw)}));'`
- `git diff --check && git diff --cached --check`

Supersedes #4, #6, #7, #8, and #17 if maintainers prefer one integrated PR.
