### PR TITLE
Full automate session lifecycle

### DIFF
--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -211,8 +211,8 @@ Full CLI pipeline — no Caido UI needed:
 # Create session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
 
-# Set placeholders and payloads via CLI
-npx tsx caido-client.ts set-placeholder <id> --search ':"' --length 4
+# Set placeholders — search for FUZZ, placeholder covers FUZZ
+npx tsx caido-client.ts set-placeholder <id> --search FUZZ
 npx tsx caido-client.ts set-payload <id> --list 'payload1,payload2'
 
 # Run and get results

--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -1,10 +1,10 @@
 # Caido Mode
 
-Full SDK CLI for [Caido](https://caido.io) built on the official [`@caido/sdk-client`](https://github.com/caido/sdk-js) package. Search HTTP history, edit/replay requests with preserved auth, manage scopes/filters/environments, create findings, export curl commands, control intercept, and fuzz — all from the terminal.
+Full SDK CLI for [Caido](https://caido.io) built on [`@caido/sdk-client`](https://github.com/caido/sdk-js). Search HTTP history, edit/replay requests with preserved auth, manage scopes/filters/environments, create findings, export curl, control intercept, and fuzz — all from the terminal.
 
 ## Why?
 
-Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies into every test request, you:
+Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies into every test request:
 
 1. Find an organic request in Caido's history that already has valid auth
 2. Use `edit` to change just the path/method/body while keeping all auth intact
@@ -19,7 +19,7 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 | **Replay Tab Lookup** | `get-session`, `replay-entries`, `session-entries` |
 | **Sessions** | `create-session`, `rename-session`, `move-session`, `replay-sessions`, `delete-sessions` |
 | **Collections** | `replay-collections`, `create-collection`, `rename-collection`, `delete-collection` |
-| **Fuzzing** | `create-automate-session`, `rename-automate-session`, `edit-automate-body`, `set-placeholder`, `set-payload`, `fuzz`, `automate-results`, `automate-sessions`, `automate-tasks`, `pause-task`, `resume-task`, `cancel-task-automate`, `duplicate-automate-session`, `delete-automate-session` |
+| **Fuzzing** | `create-automate-session`, `edit-automate-session`, `set-placeholder`, `set-payload`, `fuzz`, `automate-results`, `automate-sessions`, `automate-tasks`, `pause-task`, `resume-task`, `cancel-task-automate`, `duplicate-automate-session`, `delete-automate-session` |
 | **Scopes** | `scopes`, `create-scope`, `update-scope`, `delete-scope` |
 | **Filter Presets** | `filters`, `create-filter`, `update-filter`, `delete-filter` |
 | **Environments** | `envs`, `create-env`, `select-env`, `env-set`, `delete-env` |
@@ -33,17 +33,15 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 
 ## Setup
 
-Requires [Node.js](https://nodejs.org) (v24+), a running Caido instance and a [PAT](https://docs.caido.io/dashboard/guides/create_pat.html).
+Requires [Node.js](https://nodejs.org) (v24+), a running Caido instance, and a [PAT](https://docs.caido.io/dashboard/guides/create_pat.html).
 
 ```bash
-# Install dependencies
 npm install
 
-# 1. Create a PAT in Dashboard → Developer → Personal Access Tokens
-# 2. Setup (validates PAT via SDK and caches access token)
+# Create a PAT in Dashboard > Developer > Personal Access Tokens, then:
 npx tsx caido-client.ts setup <your-pat>
 
-# 3. Verify it works
+# Verify
 npx tsx caido-client.ts health
 npx tsx caido-client.ts recent --limit 1
 
@@ -51,7 +49,7 @@ npx tsx caido-client.ts recent --limit 1
 export CAIDO_PAT=<your-pat>
 ```
 
-The `setup` command uses the SDK's device code flow (auto-approved by your PAT) to obtain an access token, then saves both the PAT and cached token to `~/.claude/config/secrets.json` via a custom `TokenCache` implementation. Subsequent runs load the cached token directly, and a valid cached token can be used even when the PAT is absent.
+The `setup` command validates the PAT via the SDK, caches the access token to `~/.claude/config/secrets.json`. Subsequent runs load the cached token directly.
 
 ## File Structure
 
@@ -64,7 +62,9 @@ lib/
   types.ts               # Shared types (OutputOpts)
   commands/
     requests.ts          # search, recent, get, get-response, export-curl
-    replay.ts            # replay, send-raw, edit, replay-tab lookup, sessions, collections, automate, fuzz
+    replay.ts            # replay, send-raw, edit, sessions, collections
+    automate.ts          # create/edit sessions, placeholders, payloads, fuzz, results
+    composite.ts         # multi-step: idor-chain, fuzz-automate, bulk-replay, discover-auth
     findings.ts          # findings, get-finding, create-finding, update-finding
     management.ts        # scopes, filters, environments, projects, hosted-files, tasks
     intercept.ts         # intercept-status, intercept-enable, intercept-disable
@@ -78,18 +78,10 @@ All commands output JSON. Run `npx tsx caido-client.ts --help` for the complete 
 ### Search & Browse
 
 ```bash
-# Search with HTTPQL (Caido's query language)
 npx tsx caido-client.ts search 'req.method.eq:"POST" AND resp.code.eq:200'
 npx tsx caido-client.ts search 'req.host.cont:"api"' --limit 50
-npx tsx caido-client.ts search 'req.host.cont:"api"' --desc --limit 10
-
-# Get recent requests
 npx tsx caido-client.ts recent --limit 10
-
-# Full request details with raw HTTP
 npx tsx caido-client.ts get <request-id>
-
-# Just the response
 npx tsx caido-client.ts get-response <request-id>
 ```
 
@@ -98,7 +90,7 @@ npx tsx caido-client.ts get-response <request-id>
 Take an existing authenticated request and modify only what you need. Cookies, auth headers, User-Agent — everything else is preserved.
 
 ```bash
-# Change the path (IDOR testing)
+# Change path (IDOR testing)
 npx tsx caido-client.ts edit <id> --path /api/user/999
 
 # Change method + body (privilege escalation)
@@ -115,31 +107,124 @@ npx tsx caido-client.ts edit <id> --replace "user123:::user456"
 npx tsx caido-client.ts edit <id> --path /api/user/456 --session <session-id> --compact
 ```
 
-`edit`, `replay`, and `send-raw` support connection overrides for virtual-host and upstream routing tests: `--sni`, `--connect-host`, `--connect-port`, `--connect-tls`, and `--connect-no-tls`.
+`edit`, `replay`, and `send-raw` support connection overrides: `--sni`, `--connect-host`, `--connect-port`, `--connect-tls`, `--connect-no-tls`.
 
-### Replay Tab Lookup
+### Fuzzing
 
-Work directly from an existing Caido replay tab/session.
-
-```bash
-npx tsx caido-client.ts get-session <session-id-or-name> --compact
-npx tsx caido-client.ts replay-entries <session-id-or-name> --limit 20
-npx tsx caido-client.ts replay-entries <session-id-or-name> --raw --compact
-npx tsx caido-client.ts edit-session <session-id-or-name> --body '{"test":true}' --compact
-```
-
-`session-entries` is accepted as an alias for `replay-entries`.
-
-### Raw Replay
+Full CLI pipeline — no Caido UI needed. The workflow is: create session, inject FUZZ markers into the request, set placeholders to find them, set payloads per placeholder, run.
 
 ```bash
-npx tsx caido-client.ts send-raw --host example.com --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
-npx tsx caido-client.ts send-raw --host example.com --raw @request.txt --name "G /"
-cat request.txt | npx tsx caido-client.ts send-raw --host example.com --raw -
-npx tsx caido-client.ts replay <id> --connect-host 10.0.0.5 --connect-port 8443 --sni example.com
+# 1. Create session
+npx tsx caido-client.ts create-automate-session <request-id> --name "log4j-scan"
+
+# 2. Edit the raw body — replace target values with FUZZ markers
+npx tsx caido-client.ts edit-automate-session <session-id> --replace 'true:::"FUZZ"'
+
+# 3. Set placeholders — search for FUZZ markers
+npx tsx caido-client.ts set-placeholder <session-id> search FUZZ
+
+# 4. Set payloads
+npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
+
+# 5. Run
+npx tsx caido-client.ts fuzz <session-id>
+
+# 6. Get results
+npx tsx caido-client.ts automate-results <session-id>
 ```
 
-`--raw` accepts a string with C-style escapes, `@file`, or `-` for stdin.
+#### Multi-placeholder fuzzing (MATRIX strategy)
+
+For testing multiple fields simultaneously:
+
+```bash
+# Create with MATRIX strategy
+npx tsx caido-client.ts create-automate-session <request-id> --strategy MATRIX --name "upload-bypass"
+
+# Edit body — inject multiple FUZZ markers
+npx tsx caido-client.ts edit-automate-session <session-id> \
+  --replace 'filename="shell.jpg":::filename="FUZZ"' \
+  --replace 'content_type="image/jpeg":::content_type="FUZZ"'
+
+# Set placeholders — finds both FUZZ markers
+npx tsx caido-client.ts set-placeholder <session-id> search FUZZ
+
+# Set one payload set per placeholder (index = placeholder position)
+npx tsx caido-client.ts set-payload <session-id> --index 0 --list "shell.php,shell.phtml,shell.php5"
+npx tsx caido-client.ts set-payload <session-id> --index 1 --list "application/x-php,application/php"
+
+# Run — MATRIX runs the cartesian product of all sets
+npx tsx caido-client.ts fuzz <session-id>
+```
+
+#### Strategy rules
+
+| Strategy | Payload Sets | Behavior |
+|----------|-------------|----------|
+| `ALL` (default) | 1 | Every placeholder gets every payload from the single set |
+| `SEQUENTIAL` | 1 | Same as ALL |
+| `PARALLEL` | N (one per placeholder) | Simultaneous iteration — all sets must be same length |
+| `MATRIX` | N (one per placeholder) | Cartesian product — sets can be different lengths |
+
+#### Payload types
+
+```bash
+# Simple string list
+npx tsx caido-client.ts set-payload <session-id> --list "a,b,c"
+
+# Number range
+npx tsx caido-client.ts set-payload <session-id> --index 0 --range "1-1000:10"
+
+# Full config from JSON file
+npx tsx caido-client.ts set-payload <session-id> --json @payloads.json
+```
+
+JSON schema (`@payloads.json`):
+```json
+{
+  "strategy": "MATRIX",
+  "strategyOptions": { "workers": 5, "delay": 100 },
+  "payloads": [
+    { "index": 0, "type": "simpleList", "list": ["admin", "user", "test"] },
+    { "index": 1, "type": "number", "range": { "min": 1, "max": 100, "step": 1 } }
+  ]
+}
+```
+
+#### Placeholder modes
+
+```bash
+# Search for pattern — creates placeholder at every match
+npx tsx caido-client.ts set-placeholder <session-id> search FUZZ
+
+# Limit matches
+npx tsx caido-client.ts set-placeholder <session-id> search FUZZ --count 2
+
+# Explicit byte ranges
+npx tsx caido-client.ts set-placeholder <session-id> range 142 146
+npx tsx caido-client.ts set-placeholder <session-id> list 142:146 287:291
+
+# Inspect current placeholders and raw request
+npx tsx caido-client.ts set-placeholder <session-id> show-raw
+
+# Manage
+npx tsx caido-client.ts set-placeholder <session-id> clear
+npx tsx caido-client.ts set-placeholder <session-id> remove 1
+npx tsx caido-client.ts set-placeholder <session-id> replace 0 100 110
+```
+
+#### CRITICAL — Placeholder byte ranges must preserve JSON structure
+
+Caido replaces the exact byte range with the payload. If the range includes surrounding quote characters, the quotes are replaced too — producing malformed JSON.
+
+**WRONG**: body `"remember":true` → placeholder covers `true` → payload `${jndi:...}` produces `"remember":${jndi:...}` (invalid JSON)
+
+**RIGHT**: body `"remember":"FUZZ"` → placeholder covers just `FUZZ` → payload `${jndi:...}` produces `"remember":"${jndi:...}"` (valid JSON)
+
+The FUZZ marker pattern:
+1. Replace each fuzz target with `"FUZZ"` — quotes stay outside the placeholder range
+2. `set-placeholder search FUZZ` covers exactly the 4 FUZZ bytes
+3. Payloads should NOT carry their own quotes when the body provides them
 
 ### Export to curl
 
@@ -159,89 +244,34 @@ npx tsx caido-client.ts create-finding <request-id> \
 npx tsx caido-client.ts update-finding <finding-id> --title "Updated title"
 ```
 
-### Scopes
+### Scopes, Filters, Environments
 
 ```bash
-npx tsx caido-client.ts scopes
 npx tsx caido-client.ts create-scope "Target" --allow "*.target.com" --deny "*.cdn.target.com"
-npx tsx caido-client.ts update-scope <id> --allow "*.target.com,*.api.target.com"
-npx tsx caido-client.ts delete-scope <id>
-```
-
-### Filter Presets
-
-```bash
-npx tsx caido-client.ts filters
 npx tsx caido-client.ts create-filter "API Errors" --query 'req.path.cont:"/api/" AND resp.code.gte:400'
-npx tsx caido-client.ts create-filter "Auth" --query 'req.path.regex:"/(login|auth)/"' --alias "auth"
-npx tsx caido-client.ts delete-filter <id>
-```
-
-### Environments
-
-```bash
-npx tsx caido-client.ts envs
 npx tsx caido-client.ts create-env "IDOR-Test"
 npx tsx caido-client.ts env-set <env-id> victim_id "user_456"
-npx tsx caido-client.ts select-env <env-id>
-npx tsx caido-client.ts delete-env <id>
 ```
 
 ### Sessions & Collections
 
 ```bash
 npx tsx caido-client.ts create-session <request-id>
-npx tsx caido-client.ts create-session <request-id> --collection <collection-id>
 npx tsx caido-client.ts rename-session <session-id> "idor-user-profile"
-npx tsx caido-client.ts move-session <session-id> <collection-id>
 npx tsx caido-client.ts replay-sessions
-npx tsx caido-client.ts delete-sessions <id1>,<id2>
-
-npx tsx caido-client.ts replay-collections
 npx tsx caido-client.ts create-collection "IDOR Tests"
-npx tsx caido-client.ts rename-collection <id> "Auth Bypass"
-npx tsx caido-client.ts delete-collection <id>
 ```
 
-### Fuzzing
-
-Full CLI pipeline — no Caido UI needed:
+### Raw Replay
 
 ```bash
-# Create session from a staged request
-npx tsx caido-client.ts create-automate-session <request-id>
-
-# Replace target values with FUZZ markers in the raw body
-npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
-
-# Set placeholders and payloads
-npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
-npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
-
-# Run and get results
-npx tsx caido-client.ts fuzz <session-id>
-npx tsx caido-client.ts automate-results <session-id>
+npx tsx caido-client.ts send-raw --host example.com --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+npx tsx caido-client.ts send-raw --host example.com --raw @request.txt --name "G /"
+cat request.txt | npx tsx caido-client.ts send-raw --host example.com --raw -
+npx tsx caido-client.ts replay <id> --connect-host 10.0.0.5 --connect-port 8443 --sni example.com
 ```
 
-### Tasks, Projects, Info & Health
-
-```bash
-npx tsx caido-client.ts tasks
-npx tsx caido-client.ts cancel-task <task-id>
-npx tsx caido-client.ts projects
-npx tsx caido-client.ts select-project <id>
-npx tsx caido-client.ts viewer
-npx tsx caido-client.ts plugins
-npx tsx caido-client.ts health
-```
-
-### Intercept Control
-
-```bash
-npx tsx caido-client.ts intercept-status
-npx tsx caido-client.ts intercept-enable
-npx tsx caido-client.ts intercept-disable
-```
+`--raw` accepts a string with C-style escapes, `@file`, or `-` for stdin.
 
 ### Output Control
 
@@ -255,7 +285,7 @@ npx tsx caido-client.ts intercept-disable
 
 ## HTTPQL Quick Reference
 
-Caido's query language for searching HTTP history. String values must be quoted, integers are not.
+Caido's query language for searching HTTP history. String values must be quoted, integers are not. There is no `NOT` operator — use negated variants: `ne`, `ncont`, `nlike`, `nregex`.
 
 ```
 req.method.eq:"POST"                          # Match method
@@ -267,26 +297,20 @@ resp.len.gt:100000                            # Large responses
 req.method.eq:"POST" AND resp.code.eq:200     # Combine with AND/OR
 source:"replay"                               # Filter by source
 preset:"My Filter"                            # Use saved filter preset
+req.path.ncont:"/static"                      # Exclude paths (no NOT operator)
 ```
 
 ## Architecture
 
-Built on `@caido/sdk-client` v0.2.0+. Multi-file architecture with clean separation:
+Built on `@caido/sdk-client` v0.2.0+. Multi-file architecture:
 
 - **High-level SDK methods** for most features (requests, replay, findings, scopes, filters, environments, projects, hosted files, tasks, user)
 - **`client.graphql.query()`/`mutation()`** with `gql` tagged templates for features not yet in SDK (intercept, plugins, automate/fuzz)
 - **No raw fetch anywhere** — everything goes through the SDK
 
-## Claude Code Integration
+## Agent Integration
 
-This repo is designed to work as a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code). The `SKILL.md` file provides Claude with full context on how to use every command, HTTPQL syntax, and testing workflows.
-
-To install as a skill:
-
-```bash
-cp -r . ~/.claude/skills/caido-mode/
-cd ~/.claude/skills/caido-mode && npm install
-```
+This tool is designed for use by AI agents. The `SKILL.md` file provides full context on every command, HTTPQL syntax, and testing workflows. All commands output structured JSON for programmatic consumption.
 
 ## License
 

--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -19,7 +19,7 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 | **Replay Tab Lookup** | `get-session`, `replay-entries`, `session-entries` |
 | **Sessions** | `create-session`, `rename-session`, `move-session`, `replay-sessions`, `delete-sessions` |
 | **Collections** | `replay-collections`, `create-collection`, `rename-collection`, `delete-collection` |
-| **Fuzzing** | `create-automate-session`, `rename-automate-session`, `set-placeholder`, `set-payload`, `fuzz`, `automate-results`, `automate-sessions`, `automate-tasks`, `pause-task`, `resume-task`, `cancel-task-automate`, `duplicate-automate-session`, `delete-automate-session` |
+| **Fuzzing** | `create-automate-session`, `rename-automate-session`, `edit-automate-body`, `set-placeholder`, `set-payload`, `fuzz`, `automate-results`, `automate-sessions`, `automate-tasks`, `pause-task`, `resume-task`, `cancel-task-automate`, `duplicate-automate-session`, `delete-automate-session` |
 | **Scopes** | `scopes`, `create-scope`, `update-scope`, `delete-scope` |
 | **Filter Presets** | `filters`, `create-filter`, `update-filter`, `delete-filter` |
 | **Environments** | `envs`, `create-env`, `select-env`, `env-set`, `delete-env` |
@@ -211,13 +211,16 @@ Full CLI pipeline — no Caido UI needed:
 # Create session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
 
-# Set placeholders — search for FUZZ, placeholder covers FUZZ
-npx tsx caido-client.ts set-placeholder <id> --search FUZZ
-npx tsx caido-client.ts set-payload <id> --list 'payload1,payload2'
+# Replace target values with FUZZ markers in the raw body
+npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
+
+# Set placeholders and payloads
+npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
+npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
 
 # Run and get results
-npx tsx caido-client.ts fuzz <id>
-npx tsx caido-client.ts automate-results <id>
+npx tsx caido-client.ts fuzz <session-id>
+npx tsx caido-client.ts automate-results <session-id>
 ```
 
 ### Tasks, Projects, Info & Health

--- a/skills/caido-mode/README.md
+++ b/skills/caido-mode/README.md
@@ -19,7 +19,7 @@ Cookies and auth tokens are huge. Instead of copy-pasting 2KB of session cookies
 | **Replay Tab Lookup** | `get-session`, `replay-entries`, `session-entries` |
 | **Sessions** | `create-session`, `rename-session`, `move-session`, `replay-sessions`, `delete-sessions` |
 | **Collections** | `replay-collections`, `create-collection`, `rename-collection`, `delete-collection` |
-| **Fuzzing** | `create-automate-session`, `fuzz` |
+| **Fuzzing** | `create-automate-session`, `rename-automate-session`, `set-placeholder`, `set-payload`, `fuzz`, `automate-results`, `automate-sessions`, `automate-tasks`, `pause-task`, `resume-task`, `cancel-task-automate`, `duplicate-automate-session`, `delete-automate-session` |
 | **Scopes** | `scopes`, `create-scope`, `update-scope`, `delete-scope` |
 | **Filter Presets** | `filters`, `create-filter`, `update-filter`, `delete-filter` |
 | **Environments** | `envs`, `create-env`, `select-env`, `env-set`, `delete-env` |
@@ -205,10 +205,19 @@ npx tsx caido-client.ts delete-collection <id>
 
 ### Fuzzing
 
+Full CLI pipeline — no Caido UI needed:
+
 ```bash
+# Create session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
-# Configure payload markers and wordlists in Caido UI first
-npx tsx caido-client.ts fuzz <session-id>
+
+# Set placeholders and payloads via CLI
+npx tsx caido-client.ts set-placeholder <id> --search ':"' --length 4
+npx tsx caido-client.ts set-payload <id> --list 'payload1,payload2'
+
+# Run and get results
+npx tsx caido-client.ts fuzz <id>
+npx tsx caido-client.ts automate-results <id>
 ```
 
 ### Tasks, Projects, Info & Health

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: caido-mode
-description: Full Caido SDK integration for Claude Code. Search HTTP history, replay/edit requests, manage scopes/filters/environments, create findings, export curl commands, and control intercept - all via the official @caido/sdk-client. PAT auth recommended.
+description: Full Caido SDK CLI for AI agents. Search HTTP history, replay/edit requests, manage scopes/filters/environments, create findings, export curl, control intercept, and fuzz — all via @caido/sdk-client. PAT auth recommended.
 tags: [worker]
 ---
 
@@ -8,90 +8,55 @@ tags: [worker]
 
 ## Overview
 
-Full-coverage CLI for Caido's API, built on the official `@caido/sdk-client` package. Covers:
+Full-coverage CLI for Caido's API, built on `@caido/sdk-client`. Covers HTTP history, replay/edit with preserved auth, scopes, filters, environments, findings, intercept, and the complete Automate fuzzing pipeline. All commands output JSON.
 
-- **HTTP History** - Search, retrieve, replay, edit requests with HTTPQL
-- **Replay & Sessions** - Sessions, collections, entries, fuzzing
-- **Scopes** - Create and manage testing scopes (allowlist/denylist patterns)
-- **Filter Presets** - Save and reuse HTTPQL filter presets
-- **Environments** - Store test variables (victim IDs, tokens, etc.)
-- **Findings** - Create, list, update security findings
-- **Tasks** - Monitor and cancel background tasks
-- **Projects** - Switch between testing projects
-- **Hosted Files** - Manage files served by Caido
-- **Intercept** - Enable/disable request interception programmatically
-- **Plugins** - List installed plugins
-- **Export** - Convert requests to curl commands for PoCs
-- **Health** - Check Caido instance status
+### Core Principle
 
-All traffic goes through Caido, so it appears in the UI for further analysis.
+Cookies and auth tokens are huge. Rather than copy-pasting 2KB of session cookies:
 
-### Why This Model?
-
-**Cookies and auth tokens can be huge** - session cookies, JWTs, CSRF tokens can easily be 1-2KB. Rather than manually copy-pasting:
-
-1. **Find an organic request** in Caido's HTTP history that already has valid auth
+1. **Find an organic request** in Caido's HTTP history with valid auth
 2. **Use `edit` to modify just what you need** (path, method, body) while keeping all auth headers intact
-3. **Send it** - response comes back with full context preserved
+3. **Send it** — response comes back with full context preserved
 
 ## Authentication Setup
 
-### Setup (One-Time)
-
-1. Open [Dashboard → Developer → Personal Access Tokens](https://docs.caido.io/dashboard/guides/create_pat.html)
-2. Create a new token
-3. Run:
-
 ```bash
-npx tsx ~/.claude/skills/caido-mode/caido-client.ts setup <your-pat>
+# One-time setup (validates PAT, caches access token)
+npx tsx caido-client.ts setup <your-pat>
 
 # Non-default Caido instance
-npx tsx ~/.claude/skills/caido-mode/caido-client.ts setup <pat> http://192.168.1.100:8080
+npx tsx caido-client.ts setup <pat> http://192.168.1.100:8080
 
-# Or set env var instead
+# Or set env var
 export CAIDO_PAT=caido_xxxxx
+
+# Check status
+npx tsx caido-client.ts auth-status
 ```
 
-The `setup` command validates the PAT via the SDK (which exchanges it for an access token), then saves both the PAT and the cached access token to `~/.claude/config/secrets.json`. Subsequent runs load the cached token directly, and a valid cached token can be used even when the PAT is absent.
-
-### Check Status
-
-```bash
-npx tsx ~/.claude/skills/caido-mode/caido-client.ts auth-status
-```
-
-### How Auth Works
-
-The SDK uses a device code flow internally — the PAT auto-approves it and receives an access token + refresh token. A custom `SecretsTokenCache` (implementing the SDK's `TokenCache` interface) persists these tokens to secrets.json so they survive across CLI invocations.
-
-Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → valid cached access token → error with setup instructions
-
-## CLI Tool
-
-Located at `~/.claude/skills/caido-mode/caido-client.ts`. All commands output JSON.
+Auth resolution: `CAIDO_PAT` env var → `secrets.json` PAT → valid cached access token → error with setup instructions.
 
 ---
 
-## HTTP History & Testing Commands
+## HTTP History & Testing
 
-### search - Search HTTP history with HTTPQL
+### search — Search HTTP history with HTTPQL
 
 ```bash
 npx tsx caido-client.ts search 'req.method.eq:"POST" AND resp.code.eq:200'
 npx tsx caido-client.ts search 'req.host.cont:"api"' --limit 50
-npx tsx caido-client.ts search 'req.host.cont:"api"' --desc --limit 10
 npx tsx caido-client.ts search 'req.path.cont:"/admin"' --ids-only
 npx tsx caido-client.ts search 'resp.raw.cont:"password"' --after <cursor>
 ```
 
-### recent - Get recent requests
+### recent — Get recent requests
 
 ```bash
 npx tsx caido-client.ts recent
 npx tsx caido-client.ts recent --limit 50
 ```
 
-### get / get-response - Retrieve full details
+### get / get-response — Retrieve full details
 
 ```bash
 npx tsx caido-client.ts get <request-id>
@@ -100,79 +65,56 @@ npx tsx caido-client.ts get-response <request-id>
 npx tsx caido-client.ts get-response <request-id> --compact
 ```
 
-### edit - Edit and replay (KEY FEATURE)
+### edit — Edit and replay (KEY FEATURE)
 
-Modifies an existing request while preserving all cookies/auth headers:
+Preserves all cookies/auth headers. Modify only what you need:
 
 ```bash
-# Change path (IDOR testing)
-npx tsx caido-client.ts edit <id> --path /api/user/999
-
-# Change method and add body
-npx tsx caido-client.ts edit <id> --method POST --body '{"admin":true}'
-
-# Add/remove headers
-npx tsx caido-client.ts edit <id> --set-header "X-Forwarded-For: 127.0.0.1"
-npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"
-
-# Find/replace text anywhere in request
-npx tsx caido-client.ts edit <id> --replace "user123:::user456"
-
-# Combine multiple edits
-npx tsx caido-client.ts edit <id> --method PUT --path /api/admin --body '{"role":"admin"}' --compact
-
-# Reuse an existing replay tab/session for repeated probes
-npx tsx caido-client.ts edit <id> --path /api/user/1001 --session <session-id> --compact
+npx tsx caido-client.ts edit <id> --path /api/user/999                          # IDOR test
+npx tsx caido-client.ts edit <id> --method POST --body '{"admin":true}'         # priv-esc
+npx tsx caido-client.ts edit <id> --set-header "X-Forwarded-For: 127.0.0.1"    # bypass
+npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"                # CSRF removal
+npx tsx caido-client.ts edit <id> --replace "user123:::user456"                 # find/replace
+npx tsx caido-client.ts edit <id> --session <session-id> --compact              # reuse session
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--method <METHOD>` | Change HTTP method |
 | `--path <path>` | Change request path |
-| `--set-header <Name: Value>` | Add or replace a header (repeatable) |
-| `--remove-header <Name>` | Remove a header (repeatable) |
+| `--set-header <N:V>` | Add or replace header (repeatable) |
+| `--remove-header <Name>` | Remove header (repeatable) |
 | `--body <content>` | Set request body (auto-updates Content-Length) |
-| `--replace <from>:::<to>` | Find/replace text anywhere in request (repeatable) |
-| `--session <id>` | Reuse an existing replay session instead of creating a new tab |
-| `--collection <id>` | Put a newly created replay session in a collection |
+| `--replace <from>:::<to>` | Find/replace in raw request (repeatable) |
+| `--session <id>` | Reuse existing replay session |
+| `--collection <id>` | Put new session in a collection |
 | `--sni <host>` | Override TLS SNI |
-| `--connect-host <host>` | Connect to a different host while preserving the HTTP request |
-| `--connect-port <port>` | Connect to a different port |
-| `--connect-tls` / `--connect-no-tls` | Force TLS/plaintext for the connection |
+| `--connect-host <host>` | Connect to different host |
+| `--connect-port <port>` | Connect to different port |
+| `--connect-tls` / `--connect-no-tls` | Force TLS/plaintext |
 
-### replay / send-raw - Send requests
+### replay / send-raw — Send requests
 
 ```bash
-# Replay as-is
 npx tsx caido-client.ts replay <request-id>
-
-# Replay with custom raw
 npx tsx caido-client.ts replay <id> --raw "GET /modified HTTP/1.1\r\nHost: example.com\r\n\r\n"
-
-# Send completely custom request
 npx tsx caido-client.ts send-raw --host example.com --port 443 --tls --raw "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 npx tsx caido-client.ts send-raw --host example.com --raw @request.txt --name "G /"
 cat request.txt | npx tsx caido-client.ts send-raw --host example.com --raw -
-
-# Connect elsewhere while preserving the request Host/SNI you need
 npx tsx caido-client.ts replay <id> --connect-host 10.0.0.5 --connect-port 8443 --sni example.com
 ```
 
-`--raw` accepts a string with `\r\n` escapes, `@file` to read from disk, or `-` to read from stdin.
+`--raw` accepts a string with `\r\n` escapes, `@file`, or `-` for stdin.
 
-### export-curl - Convert to curl for PoCs
+### export-curl — Convert to curl for PoCs
 
 ```bash
 npx tsx caido-client.ts export-curl <request-id>
 ```
 
-Outputs a ready-to-use curl command with all headers and body.
-
 ---
 
 ## Replay Tab Lookup
-
-Use these when a Caido replay tab is already open and you want to work from its active entry directly.
 
 ```bash
 npx tsx caido-client.ts get-session <session-id-or-name> --compact
@@ -181,174 +123,238 @@ npx tsx caido-client.ts replay-entries <session-id-or-name> --raw --compact
 npx tsx caido-client.ts edit-session <session-id-or-name> --body '{"test":true}' --compact
 ```
 
-`session-entries` is accepted as an alias for `replay-entries`.
+`session-entries` is an alias for `replay-entries`.
 
 ---
 
 ## Replay Sessions & Collections
 
-### Sessions
-
 ```bash
-# Create replay session from an existing request
+# Sessions
 npx tsx caido-client.ts create-session <request-id>
 npx tsx caido-client.ts create-session <request-id> --collection <collection-id>
-
-# ALWAYS rename sessions for easy identification in Caido UI
 npx tsx caido-client.ts rename-session <session-id> "idor-user-profile"
-
-# List all replay sessions
-npx tsx caido-client.ts replay-sessions
-npx tsx caido-client.ts replay-sessions --limit 50
-
-# Move sessions between collections
 npx tsx caido-client.ts move-session <session-id> <collection-id>
+npx tsx caido-client.ts replay-sessions --limit 50
+npx tsx caido-client.ts delete-sessions <id-1>,<id-2>
 
-# Delete replay sessions
-npx tsx caido-client.ts delete-sessions <session-id-1>,<session-id-2>
-```
-
-### Collections
-
-Organize replay sessions into collections:
-
-```bash
-# List replay collections
+# Collections
 npx tsx caido-client.ts replay-collections
-npx tsx caido-client.ts replay-collections --limit 50
-
-# Create a collection
 npx tsx caido-client.ts create-collection "IDOR Testing"
-
-# Rename a collection
-npx tsx caido-client.ts rename-collection <collection-id> "Auth Bypass Tests"
-
-# Delete a collection
-npx tsx caido-client.ts delete-collection <collection-id>
+npx tsx caido-client.ts rename-collection <id> "Auth Bypass Tests"
+npx tsx caido-client.ts delete-collection <id>
 ```
 
-### Fuzzing
+---
 
-Full-automation pipeline via the SDK. No Caido UI needed.
+## Fuzzing (Automate)
 
-First, prepare the raw body with FUZZ markers, then set placeholders:
+Full CLI pipeline — no Caido UI needed. The workflow:
+
+```
+create → edit (inject FUZZ markers) → set-placeholder → set-payload → fuzz → results
+```
+
+### create-automate-session
 
 ```bash
-# 1. Create automate session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
-
-# 2. Rename for identification
-npx tsx caido-client.ts rename-automate-session <session-id> "my-fuzz"
-
-# 3. Edit the raw body — replace target values with FUZZ markers
-#    (Quotes are outside the marker, so payloads produce valid JSON)
-npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
-
-# 4. Set injection points — search for FUZZ, placeholder covers FUZZ
-npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
-
-# 5. Set payload list (comma-separated, no embedded quotes)
-npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
-
-# 6. Start fuzzing
-npx tsx caido-client.ts fuzz <session-id>
-
-# 7. Get results
-npx tsx caido-client.ts automate-results <session-id>
+npx tsx caido-client.ts create-automate-session <request-id> --name "log4j-scan" --strategy MATRIX
+npx tsx caido-client.ts create-automate-session <request-id> --strategy PARALLEL --strategy-options '{"workers":10,"delay":50}'
 ```
 
-**`--search` matches only the first occurrence**. For multiple placeholders,
-run `set-placeholder` once per field with a unique search string, or use
-`--start --end` with computed byte offsets.
+| Flag | Description |
+|------|-------------|
+| `--name <str>` | Session name |
+| `--strategy <ALL\|SEQUENTIAL\|PARALLEL\|MATRIX>` | Strategy (default: ALL) |
+| `--strategy-options <json>` | `{"workers":5,"delay":100,"redirectStrategy":"NEVER"}` |
 
-**CRITICAL — Placeholder byte ranges must preserve JSON structure**:
-Caido replaces the exact byte range with the payload. If the range includes
-surrounding quote characters, the quotes are replaced too — producing
-malformed JSON.
+### edit-automate-session
 
-**WRONG**: body `"remember":true` → placeholder covers `true` (no quotes)
-→ payload `${jndi:...}` produces `"remember":${jndi:...}` (invalid JSON)
+Unified edit — rename, change strategy, modify request body, headers, method, path:
 
-**RIGHT**: body `"remember":"FUZZ"` → placeholder covers just `FUZZ`
-→ payload `${jndi:...}` produces `"remember":"${jndi:...}"` (valid JSON)
+```bash
+# Rename
+npx tsx caido-client.ts edit-automate-session <id> --name "new-name"
+
+# Inject FUZZ markers
+npx tsx caido-client.ts edit-automate-session <id> --replace 'true:::"FUZZ"'
+npx tsx caido-client.ts edit-automate-session <id> --replace 'user_id=123:::user_id=FUZZ' --replace 'role=user:::role=FUZZ'
+
+# Change strategy
+npx tsx caido-client.ts edit-automate-session <id> --strategy MATRIX
+
+# Full body replacement
+npx tsx caido-client.ts edit-automate-session <id> --body '{"userId":"FUZZ","roleId":"FUZZ"}'
+
+# Headers / method / path
+npx tsx caido-client.ts edit-automate-session <id> --set-header "X-Forwarded-For:FUZZ" --method POST
+```
+
+| Flag | Description |
+|------|-------------|
+| `--name <str>` | Rename session |
+| `--strategy <ALL\|SEQUENTIAL\|PARALLEL\|MATRIX>` | Change strategy |
+| `--strategy-options <json>` | `{"workers":5,"delay":100}` |
+| `--replace <from>:::<to>` | Find/replace in raw request (repeatable) |
+| `--set-header <N:V>` | Set/replace header (repeatable) |
+| `--remove-header <name>` | Remove header (repeatable) |
+| `--body <raw-body>` | Full body replacement |
+| `--method <METHOD>` | Change HTTP method |
+| `--path <path>` | Change request path |
+
+### set-placeholder
+
+Mode-based. Marks injection points in the raw request.
+
+```bash
+# Search for pattern — creates placeholder at every occurrence
+npx tsx caido-client.ts set-placeholder <id> search FUZZ
+npx tsx caido-client.ts set-placeholder <id> search FUZZ --count 2
+
+# Explicit byte ranges
+npx tsx caido-client.ts set-placeholder <id> range 142 146
+npx tsx caido-client.ts set-placeholder <id> list 142:146 287:291 411:415
+
+# Inspect
+npx tsx caido-client.ts set-placeholder <id> show-raw
+
+# Manage
+npx tsx caido-client.ts set-placeholder <id> clear
+npx tsx caido-client.ts set-placeholder <id> remove 1
+npx tsx caido-client.ts set-placeholder <id> replace 0 100 110
+```
+
+| Mode | Description |
+|------|-------------|
+| `search <pattern> [--count N]` | Find all occurrences, create placeholder at each |
+| `range <start> <end>` | Single placeholder at byte range |
+| `list <start:end>...` | Multiple explicit ranges |
+| `show-raw` | Display raw request with byte offsets and current placeholders |
+| `clear` | Remove all placeholders |
+| `remove <index>` | Remove placeholder at index |
+| `replace <index> <start> <end>` | Replace placeholder at index |
+
+### set-payload
+
+Assign payloads to placeholders.
+
+```bash
+# Single set (backward compat, for ALL/SEQUENTIAL)
+npx tsx caido-client.ts set-payload <id> --list "admin,user,test"
+
+# Set payload at placeholder index (for PARALLEL/MATRIX)
+npx tsx caido-client.ts set-payload <id> --index 0 --list "admin,user,test"
+npx tsx caido-client.ts set-payload <id> --index 1 --list "true,false"
+
+# Number range at index
+npx tsx caido-client.ts set-payload <id> --index 0 --range "1-1000:10"
+
+# Remove set at index
+npx tsx caido-client.ts set-payload <id> --index 2 --remove
+
+# Full config from JSON
+npx tsx caido-client.ts set-payload <id> --json @payloads.json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--list "a,b,c"` | Comma-separated payload values |
+| `--json @file` | Full config from JSON file |
+| `--index N` | Target payload set at index (add/replace) |
+| `--range "min-max[:step]"` | Number range (`:step` optional, default 1) |
+| `--index N --remove` | Remove payload set at index |
+
+### Strategy Rules
+
+| Strategy | Payload Sets | Behavior | Constraint |
+|----------|-------------|----------|------------|
+| `ALL` (default) | 1 | Every placeholder gets every payload | — |
+| `SEQUENTIAL` | 1 | Same as ALL | — |
+| `PARALLEL` | N (one per placeholder) | Simultaneous iteration | All sets must be same length |
+| `MATRIX` | N (one per placeholder) | Cartesian product | — |
+
+PARALLEL and MATRIX require one payload set per placeholder. The CLI validates this.
+
+### Payload JSON Schema
+
+```json
+{
+  "strategy": "MATRIX",
+  "strategyOptions": { "workers": 5, "delay": 100, "redirectStrategy": "NEVER" },
+  "payloads": [
+    { "index": 0, "type": "simpleList", "list": ["admin", "user", "test"] },
+    { "index": 1, "type": "number", "range": { "min": 1, "max": 100, "step": 1 } },
+    { "index": 2, "type": "simpleList", "list": [".php", ".phtml"], "preprocessors": ["urlencode"] }
+  ]
+}
+```
+
+Types: `simpleList` (string list), `number` (range with min/max/step).
+
+### fuzz / results / lifecycle
+
+```bash
+npx tsx caido-client.ts fuzz <session-id>
+npx tsx caido-client.ts automate-results <session-id>
+npx tsx caido-client.ts automate-sessions --limit 50
+npx tsx caido-client.ts automate-tasks
+npx tsx caido-client.ts pause-task <task-id>
+npx tsx caido-client.ts resume-task <task-id>
+npx tsx caido-client.ts cancel-task-automate <task-id>
+npx tsx caido-client.ts duplicate-automate-session <id>
+npx tsx caido-client.ts delete-automate-session <id>
+npx tsx caido-client.ts rename-automate-entry <entry-id> "popped"
+npx tsx caido-client.ts delete-automate-entries <id-1>,<id-2>
+```
+
+### CRITICAL — Placeholder byte ranges and JSON structure
+
+Caido replaces the exact byte range. If the range includes quotes, they get replaced too — malformed JSON.
+
+**WRONG**: `"remember":true` → placeholder on `true` → payload `${jndi:...}` → `"remember":${jndi:...}` (broken)
+
+**RIGHT**: `"remember":"FUZZ"` → placeholder on `FUZZ` (4 bytes, quotes outside) → payload `${jndi:...}` → `"remember":"${jndi:...}"` (valid)
 
 **The FUZZ marker pattern**:
-1. In the raw body, replace each fuzz target with `"FUZZ"` (4 bytes)
-2. Quotes go at bytes *before* and *after* `FUZZ` — outside the placeholder range
-3. Set placeholder to cover exactly the 4 `FUZZ` bytes
-4. This keeps JSON valid for any payload and eliminates quote-matching errors
-
-For JSON APIs: convert boolean fields to quoted strings before fuzzing.
-Change `"remember":true` to `"remember":"FUZZ"` so string payloads
-produce valid JSON.
+1. Replace each target with `"FUZZ"` — quotes stay outside the 4-byte range
+2. `set-placeholder search FUZZ` covers exactly those 4 bytes
+3. Payloads carry no quotes when the body provides them — `"FUZZ"` + payload `${jndi:...}` = `"${jndi:...}"`
 
 ---
 
 ## Scope Management
 
-Define what's in scope for your testing. Uses glob patterns.
-
 ```bash
-# List all scopes
 npx tsx caido-client.ts scopes
-
-# Create scope with allowlist and denylist
 npx tsx caido-client.ts create-scope "Target Corp" --allow "*.target.com,*.target.io" --deny "*.cdn.target.com"
-
-# Update scope
-npx tsx caido-client.ts update-scope <scope-id> --allow "*.target.com,*.api.target.com"
-
-# Delete scope
-npx tsx caido-client.ts delete-scope <scope-id>
+npx tsx caido-client.ts update-scope <id> --allow "*.target.com,*.api.target.com"
+npx tsx caido-client.ts delete-scope <id>
 ```
-
-**Glob patterns:** `*.example.com` matches any subdomain of example.com.
 
 ---
 
 ## Filter Presets
 
-Save frequently used HTTPQL queries as named presets.
-
 ```bash
-# List saved filters
 npx tsx caido-client.ts filters
-
-# Create filter preset
 npx tsx caido-client.ts create-filter "API Errors" --query 'req.path.cont:"/api/" AND resp.code.gte:400'
 npx tsx caido-client.ts create-filter "Auth Endpoints" --query 'req.path.regex:"/(login|auth|oauth)/"' --alias "auth"
-
-# Update filter
-npx tsx caido-client.ts update-filter <filter-id> --query 'req.path.cont:"/api/" AND resp.code.gte:500'
-
-# Delete filter
-npx tsx caido-client.ts delete-filter <filter-id>
+npx tsx caido-client.ts update-filter <id> --query 'req.path.cont:"/api/" AND resp.code.gte:500'
+npx tsx caido-client.ts delete-filter <id>
 ```
 
 ---
 
 ## Environment Variables
 
-Store testing variables that persist across sessions. Great for IDOR testing with multiple user IDs.
-
 ```bash
-# List environments
 npx tsx caido-client.ts envs
-
-# Create environment
 npx tsx caido-client.ts create-env "IDOR-Test"
-
-# Set variables
 npx tsx caido-client.ts env-set <env-id> victim_user_id "user_456"
 npx tsx caido-client.ts env-set <env-id> attacker_token "eyJhbG..."
-
-# Select active environment
 npx tsx caido-client.ts select-env <env-id>
-
-# Deselect environment
-npx tsx caido-client.ts select-env
-
-# Delete environment
+npx tsx caido-client.ts select-env           # deselect
 npx tsx caido-client.ts delete-env <env-id>
 ```
 
@@ -356,56 +362,30 @@ npx tsx caido-client.ts delete-env <env-id>
 
 ## Findings
 
-Create, list, and update security findings. Shows up in Caido's Findings tab.
-
 ```bash
-# List all findings
 npx tsx caido-client.ts findings
 npx tsx caido-client.ts findings --limit 50
-
-# Get a specific finding
-npx tsx caido-client.ts get-finding <finding-id>
-
-# Create finding linked to a request
-npx tsx caido-client.ts create-finding <request-id> \
-  --title "IDOR in user profile endpoint" \
-  --description "Can access other users' profiles by changing ID parameter" \
-  --reporter "rez0"
-
-# With deduplication key (prevents duplicates)
-npx tsx caido-client.ts create-finding <request-id> \
-  --title "Auth bypass on /admin" \
-  --dedupe-key "admin-auth-bypass"
-
-# Update finding
-npx tsx caido-client.ts update-finding <finding-id> \
-  --title "Updated title" \
-  --description "Updated description"
+npx tsx caido-client.ts get-finding <id>
+npx tsx caido-client.ts create-finding <request-id> --title "IDOR in user profile" --description "Can access other users' data" --reporter "rez0"
+npx tsx caido-client.ts create-finding <request-id> --title "Auth bypass" --dedupe-key "admin-auth-bypass"
+npx tsx caido-client.ts update-finding <id> --title "Updated title" --description "Updated description"
 ```
 
 ---
 
 ## Tasks
 
-Monitor and cancel background tasks (imports, exports, etc.).
-
 ```bash
-# List all tasks
 npx tsx caido-client.ts tasks
-
-# Cancel a running task
 npx tsx caido-client.ts cancel-task <task-id>
 ```
 
 ---
 
-## Project Management
+## Projects
 
 ```bash
-# List all projects
 npx tsx caido-client.ts projects
-
-# Switch active project
 npx tsx caido-client.ts select-project <project-id>
 ```
 
@@ -414,38 +394,27 @@ npx tsx caido-client.ts select-project <project-id>
 ## Hosted Files
 
 ```bash
-# List hosted files
 npx tsx caido-client.ts hosted-files
-
-# Delete hosted file
 npx tsx caido-client.ts delete-hosted-file <file-id>
 ```
 
 ---
 
-## Intercept Control
+## Intercept
 
 ```bash
-# Check intercept status
 npx tsx caido-client.ts intercept-status
-
-# Enable/disable interception
 npx tsx caido-client.ts intercept-enable
 npx tsx caido-client.ts intercept-disable
 ```
 
 ---
 
-## Info, Health & Plugins
+## Info & Health
 
 ```bash
-# Current user info
 npx tsx caido-client.ts viewer
-
-# List installed plugins
 npx tsx caido-client.ts plugins
-
-# Check Caido instance health (version, ready state)
 npx tsx caido-client.ts health
 ```
 
@@ -471,12 +440,9 @@ Caido's query language for searching HTTP history.
 
 **CRITICAL**: String values MUST be quoted. Integer values are NOT quoted.
 
-**CRITICAL**: HTTPQL has NO `NOT` operator. Never write `NOT expr`. Use the negated operator variant instead:
-- `ncont` (not contains), `nlike` (not like), `nregex` (not regex), `ne` (not equals)
-- Wrong: `NOT req.path.cont:"/admin"`
-- Right: `req.path.ncont:"/admin"`
+**CRITICAL**: No `NOT` operator. Use negated variants: `ne`, `ncont`, `nlike`, `nregex`.
 
-### Namespaces and Fields
+### Fields
 
 | Namespace | Field | Type | Description |
 |-----------|-------|------|-------------|
@@ -495,8 +461,8 @@ Caido's query language for searching HTTP history.
 | `resp` | `len` | int | Response body length |
 | `resp` | `roundtrip` | int | Roundtrip time (ms) |
 | `row` | `id` | int | Request ID |
-| `source` | - | special | `"intercept"`, `"replay"`, `"automate"`, `"workflow"` |
-| `preset` | - | special | Filter preset reference |
+| `source` | — | special | `"intercept"`, `"replay"`, `"automate"`, `"workflow"` |
+| `preset` | — | special | Filter preset reference |
 
 ### Operators
 
@@ -507,41 +473,17 @@ Caido's query language for searching HTTP history.
 
 ### Example Queries
 
-```httpql
-# POST requests with 200 responses
+```
 req.method.eq:"POST" AND resp.code.eq:200
-
-# API requests
 req.host.cont:"api" OR req.path.cont:"/api/"
-
-# Standalone string searches both req and resp
 "password" OR "secret" OR "api_key"
-
-# Error responses
 resp.code.gte:400 AND resp.code.lt:500
-
-# Large responses (potential data exposure)
 resp.len.gt:100000
-
-# Slow endpoints
-resp.roundtrip.gt:5000
-
-# Auth endpoints by regex
 req.path.regex:"/(login|auth|signin|oauth)/"
-
-# Replay/automate traffic only
 source:"replay" OR source:"automate"
-
-# Date filtering
 req.created_at.gt:"2024-01-01T00:00:00Z"
-
-# Exclude paths (use ncont, NOT doesn't exist)
 req.path.ncont:"/static"
-
-# Not equal
 req.method.ne:"OPTIONS"
-
-# Combine negations
 req.path.ncont:"/health" AND req.path.ncont:"/metrics"
 ```
 
@@ -549,7 +491,7 @@ req.path.ncont:"/health" AND req.path.ncont:"/metrics"
 
 ## SDK Architecture
 
-This CLI is built on `@caido/sdk-client` v0.2.0+, using a clean multi-file architecture:
+Built on `@caido/sdk-client` v0.2.0+ with a clean multi-file architecture:
 
 ```
 caido-client.ts          # CLI entry point — arg parsing + command dispatch
@@ -560,187 +502,44 @@ lib/
   types.ts               # Shared types (OutputOpts)
   commands/
     requests.ts          # search, recent, get, get-response, export-curl
-    replay.ts            # replay, send-raw, edit, replay-tab lookup, sessions, collections, automate, fuzz
+    replay.ts            # replay, send-raw, edit, sessions, collections
+    automate.ts          # create/edit sessions, placeholders, payloads, fuzz, results
+    composite.ts         # idor-chain, fuzz-automate, bulk-replay, discover-auth
     findings.ts          # findings, get-finding, create-finding, update-finding
     management.ts        # scopes, filters, environments, projects, hosted-files, tasks
     intercept.ts         # intercept-status, intercept-enable, intercept-disable
     info.ts              # viewer, plugins, health, setup, auth-status
 ```
 
-### SDK Coverage
-
-Most features use the high-level SDK directly:
-
-| SDK Method | Commands |
-|-----------|----------|
-| `client.request.list()`, `.get()` | search, recent, get, get-response, export-curl |
-| `client.replay.sessions.*` | create-session, replay-sessions, rename-session, delete-sessions |
-| `client.replay.collections.*` | replay-collections, create-collection, rename-collection, delete-collection |
-| `client.replay.send()` | replay, send-raw, edit |
-| `client.finding.*` | findings, get-finding, create-finding, update-finding |
-| `client.scope.*` | scopes, create-scope, update-scope, delete-scope |
-| `client.filter.*` | filters, create-filter, update-filter, delete-filter |
-| `client.environment.*` | envs, create-env, select-env, env-set, delete-env |
-| `client.project.*` | projects, select-project |
-| `client.hostedFile.*` | hosted-files, delete-hosted-file |
-| `client.task.*` | tasks, cancel-task |
-| `client.user.viewer()` | viewer |
-| `client.health()` | health |
-
-Features not yet in the high-level SDK use `client.graphql.query()`/`client.graphql.mutation()` with `gql` tagged templates from `graphql-tag`. This is the proper SDK approach (typed documents through urql) — **no raw fetch anywhere**.
-
-| GraphQL Document | Commands |
-|-----------------|----------|
-| `INTERCEPT_OPTIONS_QUERY` | intercept-status |
-| `PAUSE_INTERCEPT` / `RESUME_INTERCEPT` | intercept-enable, intercept-disable |
-| `PLUGIN_PACKAGES_QUERY` | plugins |
-| `CREATE_AUTOMATE_SESSION` | create-automate-session |
-| `GET_AUTOMATE_SESSION` | fuzz (verify session), set-placeholder, set-payload |
-| `START_AUTOMATE_TASK` | fuzz (start task) |
-| `UPDATE_AUTOMATE_SESSION` | set-placeholder, set-payload |
-| `RENAME_AUTOMATE_SESSION` | rename-automate-session |
-| `AUTOMATE_SESSION_RESULTS` | automate-results |
-| `AUTOMATE_SESSIONS` / `AUTOMATE_TASKS` | automate-sessions, automate-tasks |
-| `DELETE_AUTOMATE_SESSION` / `DUPLICATE_AUTOMATE_SESSION` | delete, duplicate-automate-session |
-| `PAUSE_AUTOMATE_TASK` / `RESUME_AUTOMATE_TASK` | pause-task, resume-task |
-| `CANCEL_AUTOMATE_TASK` | cancel-task-automate |
-| `RENAME_AUTOMATE_ENTRY` / `DELETE_AUTOMATE_ENTRIES` | rename-automate-entry, delete-automate-entries |
+Most features use the high-level SDK directly. Automate/fuzz, intercept, and plugins use `client.graphql.query()`/`client.graphql.mutation()` with typed `gql` documents — no raw fetch anywhere.
 
 ---
 
-## Workflow Examples
+## Agent Instructions
 
-### 1. IDOR Testing (Primary Pattern)
+1. **Prefer `edit` over `replay --raw`** — preserves cookies/auth automatically
+2. **Workflow**: search → find request with valid auth → use that ID via `edit`
+3. **Don't dump raw requests into context** — use `--compact` or `--headers-only`
+4. **Always check auth first**: `health` → `recent --limit 1`
+5. **Always name replay sessions**: `rename-session <id> "descriptive-name"`
+6. **Create findings** for anything interesting
+7. **Use `export-curl`** for PoCs
+8. **Create filter presets** for recurring searches
+9. **Use environments** to store test data
+10. **Never use `NOT` in HTTPQL** — use `ne`, `ncont`, `nlike`, `nregex`
+11. **FUZZ marker pattern**: replace targets with `"FUZZ"`, quotes outside the range, placeholder covers just `FUZZ`
+12. **Payloads carry no quotes when body provides them**: `"FUZZ"` + `${jndi:...}` = `"${jndi:...}"`
 
-```bash
-# Find authenticated request
-npx tsx caido-client.ts search 'req.path.cont:"/api/user"' --limit 10
+## Performance
 
-# Create scope
-npx tsx caido-client.ts create-scope "IDOR-Test" --allow "*.target.com"
-
-# Create environment for test data
-npx tsx caido-client.ts create-env "IDOR-Test"
-npx tsx caido-client.ts env-set <env-id> victim_id "user_999"
-
-# Test IDOR by changing user ID
-npx tsx caido-client.ts edit <request-id> --path /api/user/999
-
-# Mark as finding if it works
-npx tsx caido-client.ts create-finding <request-id> --title "IDOR on /api/user/:id"
-
-# Export curl for PoC
-npx tsx caido-client.ts export-curl <request-id>
-```
-
-### 2. Privilege Escalation Testing
-
-```bash
-npx tsx caido-client.ts search 'req.path.cont:"/admin"' --limit 10
-npx tsx caido-client.ts edit <id> --path /api/admin/users --method GET
-npx tsx caido-client.ts edit <id> --method POST --body '{"role":"admin"}'
-```
-
-### 3. Header Bypass Testing
-
-```bash
-npx tsx caido-client.ts edit <id> --set-header "X-Forwarded-For: 127.0.0.1"
-npx tsx caido-client.ts edit <id> --set-header "X-Original-URL: /admin"
-npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"
-```
-
-### 4. Fuzzing with Automate — Full 11-Step CLI Workflow
-
-The Caido SDK supports full-automation fuzzing without touching the UI. The CLI provides the complete pipeline:
-
-```bash
-# 1. Create automate session from a staged request
-npx tsx caido-client.ts create-automate-session <request-id>
-
-# 2. Rename it to something meaningful
-npx tsx caido-client.ts rename-automate-session <session-id> "log4j-login-fuzz"
-
-# 3. (Optional) Duplicate an existing session for variant fuzzing
-npx tsx caido-client.ts duplicate-automate-session <session-id>
-
-# 4. Edit the raw body — replace target values with FUZZ markers
-npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
-
-# 5. Set injection points — search for FUZZ, placeholder covers FUZZ
-npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
-
-# 6. Set payloads (simple string list)
-npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
-
-# 7. Run the automation
-npx tsx caido-client.ts fuzz <session-id>
-
-# 8. List all automate sessions
-npx tsx caido-client.ts automate-sessions
-npx tsx caido-client.ts automate-sessions --limit 50
-
-# 9. Task lifecycle control
-npx tsx caido-client.ts automate-tasks               # list running/paused tasks
-npx tsx caido-client.ts pause-task <task-id>          # pause a running fuzz
-npx tsx caido-client.ts resume-task <task-id>         # resume a paused fuzz
-npx tsx caido-client.ts cancel-task-automate <id>     # cancel a running fuzz
-
-# 10. Get results
-npx tsx caido-client.ts automate-results <session-id>
-
-# 11. Clean up
-npx tsx caido-client.ts delete-automate-session <session-id>
-npx tsx caido-client.ts delete-automate-entries <id-1>,<id-2>
-npx tsx caido-client.ts rename-automate-entry <entry-id> "popped"
-```
-
-### 5. Filter + Analyze Pattern
-
-```bash
-# Save useful filters
-npx tsx caido-client.ts create-filter "API 4xx" --query 'req.path.cont:"/api/" AND resp.code.gte:400 AND resp.code.lt:500'
-npx tsx caido-client.ts create-filter "Large Responses" --query 'resp.len.gt:100000'
-npx tsx caido-client.ts create-filter "Sensitive Data" --query '"password" OR "secret" OR "api_key" OR "token"'
-
-# Quick search using preset alias
-npx tsx caido-client.ts search 'preset:"API 4xx"' --limit 20
-```
-
----
-
-## Instructions for Claude
-
-1. **PREFER `edit` OVER `replay --raw`** - preserves cookies/auth automatically
-2. **Workflow**: Search → find request with valid auth → use that ID for all tests via `edit`
-3. **Don't dump raw requests into context** - use `--compact` or `--headers-only` when exploring
-4. **Always check auth first**: `health` to verify connection, then `recent --limit 1`
-5. **ALWAYS NAME REPLAY TABS**: `rename-session <id> "idor-user-profile"`
-6. **Create findings** for anything interesting - they show up in Caido's Findings tab
-7. **Use `export-curl`** when building PoCs for reports
-8. **Create filter presets** for recurring searches to save typing
-9. **Use environments** to store test data (victim IDs, tokens, etc.)
-10. **Output is JSON** - parse response fields as needed
-11. **NEVER use `NOT` in HTTPQL** - it doesn't exist. Use negated operators: `ne`, `ncont`, `nlike`, `nregex`
-12. **Placeholder ranges must NOT include surrounding quotes** — Caido replaces the exact byte range with the payload. If `--start`/`--end` includes quote characters, the quotes are replaced and the result is malformed JSON. Use `FUZZ` as a same-length marker with quotes outside the range.
-13. **Payloads must NOT carry their own quotes when body provides them** — If the body has `"username":"FUZZ"`, the payload should be `${jndi:...}`, not `"${jndi:...}"`. The payload replaces `FUZZ` inside the existing quotes.
-
-## Performance & Context Optimization
-
-- `search`/`recent` omit `raw` field (~200 bytes per request, safe for 100+)
-- `get` fetches `raw` (~5-20KB per request, fetch only what you need)
+- `search`/`recent` omit `raw` field (~200 bytes/request, safe for 100+)
+- `get` fetches `raw` (~5-20KB/request — fetch only what you need)
 - Use `--limit` aggressively (start with 5-10)
-- Use `--compact` flag for quick exploration
+- Use `--compact` for quick exploration
 - Filter server-side with HTTPQL, not client-side
 
 ## Error Handling
 
-- **Auth errors**: Run `npx tsx caido-client.ts auth-status` to check, re-setup with `npx tsx caido-client.ts setup <pat>`
-- **Connection refused**: Caido not running → `npx tsx caido-client.ts health`
-- **InstanceNotReadyError**: Caido is starting up, wait and retry
-
-## Related Skills
-
-- `caido-plugin-dev` - For building Caido plugins (backend + frontend)
-- `spider` - Crawling with Katana (uses Caido as proxy)
-- `website-fuzzing` - Remote ffuf fuzzing on hunt6
-- `JsAnalyzer` - JS analysis for traffic-discovered files
+- **Auth errors**: `auth-status` to check, `setup <pat>` to re-setup
+- **Connection refused**: Caido not running → `health`
+- **InstanceNotReadyError**: Caido starting up, wait and retry

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -238,10 +238,8 @@ npx tsx caido-client.ts create-automate-session <request-id>
 # 2. Rename for identification
 npx tsx caido-client.ts rename-automate-session <session-id> "my-fuzz"
 
-# 3. Set injection points (byte-offset placeholders in raw request)
-#    For a body with "FUZZ" markers, search for the string before the
-#    value and use --length to cover the 4 FUZZ bytes:
-npx tsx caido-client.ts set-placeholder <session-id> --search ':"' --length 4
+# 3. Set injection points — search for FUZZ, placeholder covers FUZZ
+npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
 
 # 4. Set payload list (comma-separated, no embedded quotes)
 npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
@@ -253,9 +251,9 @@ npx tsx caido-client.ts fuzz <session-id>
 npx tsx caido-client.ts automate-results <session-id>
 ```
 
-**--search matches only the first occurrence**. For multiple placeholders,
+**`--search` matches only the first occurrence**. For multiple placeholders,
 run `set-placeholder` once per field with a unique search string, or use
-`--start --end` with computed byte offsets:
+`--start --end` with computed byte offsets.
 
 **CRITICAL — Placeholder byte ranges must preserve JSON structure**:
 Caido replaces the exact byte range with the payload. If the range includes
@@ -659,9 +657,8 @@ npx tsx caido-client.ts rename-automate-session <session-id> "log4j-login-fuzz"
 # 3. (Optional) Duplicate an existing session for variant fuzzing
 npx tsx caido-client.ts duplicate-automate-session <session-id>
 
-# 4. Set injection points on FUZZ markers in the raw body
-#    First replace fuzz targets with "FUZZ", then:
-npx tsx caido-client.ts set-placeholder <session-id> --search ':"' --length 4
+# 4. Set injection points — search for FUZZ, placeholder covers FUZZ
+npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
 
 # 5. Set payloads (simple string list)
 npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -231,6 +231,8 @@ npx tsx caido-client.ts delete-collection <collection-id>
 
 Full-automation pipeline via the SDK. No Caido UI needed.
 
+First, prepare the raw body with FUZZ markers, then set placeholders:
+
 ```bash
 # 1. Create automate session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
@@ -238,16 +240,20 @@ npx tsx caido-client.ts create-automate-session <request-id>
 # 2. Rename for identification
 npx tsx caido-client.ts rename-automate-session <session-id> "my-fuzz"
 
-# 3. Set injection points — search for FUZZ, placeholder covers FUZZ
+# 3. Edit the raw body — replace target values with FUZZ markers
+#    (Quotes are outside the marker, so payloads produce valid JSON)
+npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
+
+# 4. Set injection points — search for FUZZ, placeholder covers FUZZ
 npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
 
-# 4. Set payload list (comma-separated, no embedded quotes)
+# 5. Set payload list (comma-separated, no embedded quotes)
 npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
 
-# 5. Start fuzzing
+# 6. Start fuzzing
 npx tsx caido-client.ts fuzz <session-id>
 
-# 6. Get results
+# 7. Get results
 npx tsx caido-client.ts automate-results <session-id>
 ```
 
@@ -643,7 +649,7 @@ npx tsx caido-client.ts edit <id> --set-header "X-Original-URL: /admin"
 npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"
 ```
 
-### 4. Fuzzing with Automate — Full 12-Step CLI Workflow
+### 4. Fuzzing with Automate — Full 11-Step CLI Workflow
 
 The Caido SDK supports full-automation fuzzing without touching the UI. The CLI provides the complete pipeline:
 
@@ -657,29 +663,32 @@ npx tsx caido-client.ts rename-automate-session <session-id> "log4j-login-fuzz"
 # 3. (Optional) Duplicate an existing session for variant fuzzing
 npx tsx caido-client.ts duplicate-automate-session <session-id>
 
-# 4. Set injection points — search for FUZZ, placeholder covers FUZZ
+# 4. Edit the raw body — replace target values with FUZZ markers
+npx tsx caido-client.ts edit-automate-body <session-id> --replace 'true:::"FUZZ"'
+
+# 5. Set injection points — search for FUZZ, placeholder covers FUZZ
 npx tsx caido-client.ts set-placeholder <session-id> --search FUZZ
 
-# 5. Set payloads (simple string list)
+# 6. Set payloads (simple string list)
 npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
 
-# 6. Run the automation
+# 7. Run the automation
 npx tsx caido-client.ts fuzz <session-id>
 
-# 7. List all automate sessions
+# 8. List all automate sessions
 npx tsx caido-client.ts automate-sessions
 npx tsx caido-client.ts automate-sessions --limit 50
 
-# 8. Task lifecycle control
+# 9. Task lifecycle control
 npx tsx caido-client.ts automate-tasks               # list running/paused tasks
 npx tsx caido-client.ts pause-task <task-id>          # pause a running fuzz
 npx tsx caido-client.ts resume-task <task-id>         # resume a paused fuzz
 npx tsx caido-client.ts cancel-task-automate <id>     # cancel a running fuzz
 
-# 9. Get results
+# 10. Get results
 npx tsx caido-client.ts automate-results <session-id>
 
-# 10. Clean up
+# 11. Clean up
 npx tsx caido-client.ts delete-automate-session <session-id>
 npx tsx caido-client.ts delete-automate-entries <id-1>,<id-2>
 npx tsx caido-client.ts rename-automate-entry <entry-id> "popped"

--- a/skills/caido-mode/SKILL.md
+++ b/skills/caido-mode/SKILL.md
@@ -229,13 +229,54 @@ npx tsx caido-client.ts delete-collection <collection-id>
 
 ### Fuzzing
 
+Full-automation pipeline via the SDK. No Caido UI needed.
+
 ```bash
-# Create automate session for fuzzing
+# 1. Create automate session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
 
-# Start fuzzing (configure payloads and markers in Caido UI first)
+# 2. Rename for identification
+npx tsx caido-client.ts rename-automate-session <session-id> "my-fuzz"
+
+# 3. Set injection points (byte-offset placeholders in raw request)
+#    For a body with "FUZZ" markers, search for the string before the
+#    value and use --length to cover the 4 FUZZ bytes:
+npx tsx caido-client.ts set-placeholder <session-id> --search ':"' --length 4
+
+# 4. Set payload list (comma-separated, no embedded quotes)
+npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
+
+# 5. Start fuzzing
 npx tsx caido-client.ts fuzz <session-id>
+
+# 6. Get results
+npx tsx caido-client.ts automate-results <session-id>
 ```
+
+**--search matches only the first occurrence**. For multiple placeholders,
+run `set-placeholder` once per field with a unique search string, or use
+`--start --end` with computed byte offsets:
+
+**CRITICAL — Placeholder byte ranges must preserve JSON structure**:
+Caido replaces the exact byte range with the payload. If the range includes
+surrounding quote characters, the quotes are replaced too — producing
+malformed JSON.
+
+**WRONG**: body `"remember":true` → placeholder covers `true` (no quotes)
+→ payload `${jndi:...}` produces `"remember":${jndi:...}` (invalid JSON)
+
+**RIGHT**: body `"remember":"FUZZ"` → placeholder covers just `FUZZ`
+→ payload `${jndi:...}` produces `"remember":"${jndi:...}"` (valid JSON)
+
+**The FUZZ marker pattern**:
+1. In the raw body, replace each fuzz target with `"FUZZ"` (4 bytes)
+2. Quotes go at bytes *before* and *after* `FUZZ` — outside the placeholder range
+3. Set placeholder to cover exactly the 4 `FUZZ` bytes
+4. This keeps JSON valid for any payload and eliminates quote-matching errors
+
+For JSON APIs: convert boolean fields to quoted strings before fuzzing.
+Change `"remember":true` to `"remember":"FUZZ"` so string payloads
+produce valid JSON.
 
 ---
 
@@ -550,8 +591,16 @@ Features not yet in the high-level SDK use `client.graphql.query()`/`client.grap
 | `PAUSE_INTERCEPT` / `RESUME_INTERCEPT` | intercept-enable, intercept-disable |
 | `PLUGIN_PACKAGES_QUERY` | plugins |
 | `CREATE_AUTOMATE_SESSION` | create-automate-session |
-| `GET_AUTOMATE_SESSION` | fuzz (verify session) |
+| `GET_AUTOMATE_SESSION` | fuzz (verify session), set-placeholder, set-payload |
 | `START_AUTOMATE_TASK` | fuzz (start task) |
+| `UPDATE_AUTOMATE_SESSION` | set-placeholder, set-payload |
+| `RENAME_AUTOMATE_SESSION` | rename-automate-session |
+| `AUTOMATE_SESSION_RESULTS` | automate-results |
+| `AUTOMATE_SESSIONS` / `AUTOMATE_TASKS` | automate-sessions, automate-tasks |
+| `DELETE_AUTOMATE_SESSION` / `DUPLICATE_AUTOMATE_SESSION` | delete, duplicate-automate-session |
+| `PAUSE_AUTOMATE_TASK` / `RESUME_AUTOMATE_TASK` | pause-task, resume-task |
+| `CANCEL_AUTOMATE_TASK` | cancel-task-automate |
+| `RENAME_AUTOMATE_ENTRY` / `DELETE_AUTOMATE_ENTRIES` | rename-automate-entry, delete-automate-entries |
 
 ---
 
@@ -596,12 +645,47 @@ npx tsx caido-client.ts edit <id> --set-header "X-Original-URL: /admin"
 npx tsx caido-client.ts edit <id> --remove-header "X-CSRF-Token"
 ```
 
-### 4. Fuzzing with Automate
+### 4. Fuzzing with Automate — Full 12-Step CLI Workflow
+
+The Caido SDK supports full-automation fuzzing without touching the UI. The CLI provides the complete pipeline:
 
 ```bash
+# 1. Create automate session from a staged request
 npx tsx caido-client.ts create-automate-session <request-id>
-# Configure payload markers and wordlists in Caido UI
+
+# 2. Rename it to something meaningful
+npx tsx caido-client.ts rename-automate-session <session-id> "log4j-login-fuzz"
+
+# 3. (Optional) Duplicate an existing session for variant fuzzing
+npx tsx caido-client.ts duplicate-automate-session <session-id>
+
+# 4. Set injection points on FUZZ markers in the raw body
+#    First replace fuzz targets with "FUZZ", then:
+npx tsx caido-client.ts set-placeholder <session-id> --search ':"' --length 4
+
+# 5. Set payloads (simple string list)
+npx tsx caido-client.ts set-payload <session-id> --list 'payload1,payload2'
+
+# 6. Run the automation
 npx tsx caido-client.ts fuzz <session-id>
+
+# 7. List all automate sessions
+npx tsx caido-client.ts automate-sessions
+npx tsx caido-client.ts automate-sessions --limit 50
+
+# 8. Task lifecycle control
+npx tsx caido-client.ts automate-tasks               # list running/paused tasks
+npx tsx caido-client.ts pause-task <task-id>          # pause a running fuzz
+npx tsx caido-client.ts resume-task <task-id>         # resume a paused fuzz
+npx tsx caido-client.ts cancel-task-automate <id>     # cancel a running fuzz
+
+# 9. Get results
+npx tsx caido-client.ts automate-results <session-id>
+
+# 10. Clean up
+npx tsx caido-client.ts delete-automate-session <session-id>
+npx tsx caido-client.ts delete-automate-entries <id-1>,<id-2>
+npx tsx caido-client.ts rename-automate-entry <entry-id> "popped"
 ```
 
 ### 5. Filter + Analyze Pattern
@@ -631,6 +715,8 @@ npx tsx caido-client.ts search 'preset:"API 4xx"' --limit 20
 9. **Use environments** to store test data (victim IDs, tokens, etc.)
 10. **Output is JSON** - parse response fields as needed
 11. **NEVER use `NOT` in HTTPQL** - it doesn't exist. Use negated operators: `ne`, `ncont`, `nlike`, `nregex`
+12. **Placeholder ranges must NOT include surrounding quotes** — Caido replaces the exact byte range with the payload. If `--start`/`--end` includes quote characters, the quotes are replaced and the result is malformed JSON. Use `FUZZ` as a same-length marker with quotes outside the range.
+13. **Payloads must NOT carry their own quotes when body provides them** — If the body has `"username":"FUZZ"`, the payload should be `${jndi:...}`, not `"${jndi:...}"`. The payload replaces `FUZZ` inside the existing quotes.
 
 ## Performance & Context Optimization
 

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -11,11 +11,12 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
 import { cmdReplay, cmdSendRaw, cmdEdit, cmdGetSession, cmdReplayEntries, cmdEditSession, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdMoveSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection } from "./lib/commands/replay";
 import type { ConnectionOverrides } from "./lib/commands/replay";
-import { cmdCreateAutomateSession, cmdFuzz, cmdRenameAutomateSession, cmdSetPlaceholder, cmdSetPayload, cmdAutomateResults, cmdAutomateSessions, cmdAutomateTasks, cmdDeleteAutomateSession, cmdDuplicateAutomateSession, cmdPauseAutomateTask, cmdResumeAutomateTask, cmdCancelAutomateTask, cmdRenameAutomateEntry, cmdDeleteAutomateEntries, cmdEditAutomateBody } from "./lib/commands/automate";
+import { cmdCreateAutomateSession, cmdFuzz, cmdSetPlaceholder, cmdSetPayload, cmdAutomateResults, cmdAutomateSessions, cmdAutomateTasks, cmdDeleteAutomateSession, cmdDuplicateAutomateSession, cmdPauseAutomateTask, cmdResumeAutomateTask, cmdCancelAutomateTask, cmdRenameAutomateEntry, cmdDeleteAutomateEntries, cmdEditAutomateSession } from "./lib/commands/automate";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
 import { cmdViewer, cmdPlugins, cmdHealth, cmdSetup, cmdAuthStatus } from "./lib/commands/info";
+import { cmdIdorChain, cmdFuzzAutomate, cmdBulkReplay, cmdDiscoverAuth } from "./lib/commands/composite";
 
 const DEBUG = process.env.DEBUG === "1";
 
@@ -147,25 +148,47 @@ Usage:
 ═══════════════════════════════════════════════
 
   create-automate-session <id> Create an automate session for fuzzing
-  automate-sessions            List all automate sessions
-    --limit <n>                Max results (default: 20)
-  rename-automate-session <id> <name>
-                               Rename an automate session
-  delete-automate-session <id> Delete an automate session
-  duplicate-automate-session <id>
-                               Clone an existing automate session
-  set-placeholder <session-id>  Set injection points (placeholders)
-    --start <n> --end <n>      Byte offsets in the raw request
-    --search <string>          Search for string, placeholder covers the string
-    --length <n>               Legacy: bytes to cover after the search string
-    --show-raw                 Display raw request content
+    --name <str>               Session name
+    --strategy <ALL|SEQUENTIAL|PARALLEL|MATRIX>
+                               Fuzzing strategy (default: ALL)
+    --strategy-options <json>  Advanced: {"workers":5,"delay":100,"redirectStrategy":"NEVER"}
+  edit-automate-session <id>   Edit session (unified)
+    --name <str>               Rename session
+    --strategy <ALL|SEQUENTIAL|PARALLEL|MATRIX>
+    --strategy-options <json>  Advanced: {"workers":5,"delay":100}
+    --replace <from>:::<to>    Find/replace in raw request (repeatable)
+    --set-header <N:V>         Set/replace header (repeatable)
+    --remove-header <name>     Remove header (repeatable)
+    --body <raw-body>          Full body replacement
+    --method <METHOD>          Change HTTP method
+    --path <path>              Change request path
+  set-placeholder <session-id> Set injection points (modes)
+    search <pattern>           Find all occurrences, create placeholders
+      --count <n>              Limit to first N matches
+    range <start> <end>        Single placeholder at byte range
+    list <start:end>...        Multiple explicit placeholders
+    clear                      Remove all placeholders
+    remove <index>             Remove placeholder at index
+    replace <index> <start> <end>
+                               Replace placeholder at index
+    show-raw                   Display raw request with byte offsets
   set-payload <session-id>     Set payload list
-    --list "a,b,c"             Comma-separated payload values
+    --list "a,b,c"             Comma-separated (single set, backward compat)
+    --json @file               Full config from JSON file
+    --index <n> --list "a,b,c" Set payload at index
+    --index <n> --range "min-max[:step]"
+                               Number range payload at index
+    --index <n> --remove       Remove payload set at index
   fuzz <session-id>            Start fuzzing (must have placeholders + payloads)
   automate-results <session-id>
                                Get all fuzzing results (request/response pairs)
+  automate-sessions            List all automate sessions
+    --limit <n>                Max results (default: 20)
   automate-tasks               List automate tasks
     --limit <n>                Max results (default: 20)
+  delete-automate-session <id> Delete an automate session
+  duplicate-automate-session <id>
+                               Clone an existing automate session
   pause-task <id>              Pause a running automate task
   resume-task <id>             Resume a paused automate task
   cancel-task-automate <id>    Cancel a running automate task
@@ -173,9 +196,6 @@ Usage:
                                Rename an automate entry
   delete-automate-entries <ids>
                                Delete automate entries (comma-separated)
-  edit-automate-body <session-id>
-                               Find/replace in the raw request body
-    --replace <from>:::<to>    Replace text (repeatable)
 
 ═══════════════════════════════════════════════
  FINDINGS
@@ -271,6 +291,35 @@ Usage:
   health                       Check Caido instance health
 
 ═══════════════════════════════════════════════
+ COMPOSITE COMMANDS
+═══════════════════════════════════════════════
+
+  idor-chain <base-request-id>   Test IDOR against multiple target IDs
+    --ids <list>                 Comma-separated target IDs (required)
+    --create-findings            Create findings for successful IDORs
+    --finding-title-prefix <str> Title prefix for findings (default: "IDOR on")
+    --dedupe-key-prefix <str>    Dedupe key prefix (default: "idor")
+    --max-concurrent <n>         Max concurrent requests (default: 3)
+
+  fuzz-automate <request-id>     Full 7-step fuzzing pipeline in one command
+    --payloads <list>            Comma-separated payloads (required)
+    --strategy <ALL|SEQUENTIAL|PARALLEL|MATRIX> (default: MATRIX)
+    --workers <n>                Concurrent workers (default: 5)
+    --delay <ms>                 Delay between requests (default: 100)
+    --redirect-strategy <NEVER|IN_SCOPE|SAME_SITE|ALWAYS> (default: NEVER)
+    --follow-redirects           Follow redirects during fuzzing
+
+  bulk-replay                    Replay multiple requests through proxy
+    --filter <httpql>            HTTPQL filter to select requests
+    --collection <id>            Replay collection ID
+    --rate <n>                   Requests per second (default: 10)
+    --max <n>                    Max requests to replay (default: 100)
+
+  discover-auth <base-id> <pattern>  Discover endpoints & test IDOR on each
+    --ids <list>                 Target IDs for IDOR (required)
+    --create-findings            Create findings for successful IDORs
+
+═══════════════════════════════════════════════
  OUTPUT CONTROL (works with get, get-response, replay, edit, send-raw)
 ═══════════════════════════════════════════════
 
@@ -302,6 +351,10 @@ Examples:
   npx tsx caido-client.ts create-scope "Target" --allow "*.example.com"
   npx tsx caido-client.ts replay-sessions --limit 10
   npx tsx caido-client.ts health
+  npx tsx caido-client.ts idor-chain 12345 --ids "100,101,102" --create-findings
+  npx tsx caido-client.ts fuzz-automate 12345 --payloads '\${jndi:ldap://...},\${jndi:rmi://...}' --strategy MATRIX
+  npx tsx caido-client.ts bulk-replay --filter 'req.path.cont:"/api/"' --rate 5
+  npx tsx caido-client.ts discover-auth 12345 'req.path.cont:"/api/user"' --ids "1,2,3"
 `);
 }
 
@@ -531,7 +584,40 @@ async function main() {
     // ── Automate & Fuzzing ──
     case "create-automate-session": {
       if (!args[1]) { console.error("Error: request-id required"); process.exit(1); }
-      await cmdCreateAutomateSession(args[1]);
+      let caName: string | undefined, caStrategy: string | undefined, caStrategyOptions: string | undefined;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--name" && args[i + 1]) { caName = args[i + 1]; i++; }
+        else if (args[i] === "--strategy" && args[i + 1]) { caStrategy = args[i + 1]; i++; }
+        else if (args[i] === "--strategy-options" && args[i + 1]) { caStrategyOptions = args[i + 1]; i++; }
+      }
+      await cmdCreateAutomateSession(args[1], caName, caStrategy, caStrategyOptions);
+      break;
+    }
+
+    case "edit-automate-session": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      const editOpts: any = {};
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--name" && args[i + 1]) { editOpts.name = args[i + 1]; i++; }
+        else if (args[i] === "--strategy" && args[i + 1]) { editOpts.strategy = args[i + 1]; i++; }
+        else if (args[i] === "--strategy-options" && args[i + 1]) { editOpts.strategyOptions = args[i + 1]; i++; }
+        else if (args[i] === "--replace" && args[i + 1]) {
+          if (!editOpts.replacements) editOpts.replacements = [];
+          editOpts.replacements.push(args[i + 1]); i++;
+        }
+        else if (args[i] === "--set-header" && args[i + 1]) {
+          if (!editOpts.setHeaders) editOpts.setHeaders = [];
+          editOpts.setHeaders.push(args[i + 1]); i++;
+        }
+        else if (args[i] === "--remove-header" && args[i + 1]) {
+          if (!editOpts.removeHeaders) editOpts.removeHeaders = [];
+          editOpts.removeHeaders.push(args[i + 1]); i++;
+        }
+        else if (args[i] === "--body" && args[i + 1]) { editOpts.body = args[i + 1]; i++; }
+        else if (args[i] === "--method" && args[i + 1]) { editOpts.method = args[i + 1]; i++; }
+        else if (args[i] === "--path" && args[i + 1]) { editOpts.path = args[i + 1]; i++; }
+      }
+      await cmdEditAutomateSession(args[1], editOpts);
       break;
     }
 
@@ -549,47 +635,31 @@ async function main() {
 
     case "set-placeholder": {
       if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
-
-      const explicitPlaceholders: { start: number; end: number }[] = [];
-      let searchStr: string | undefined;
-      let searchLength: number | undefined;
-      let showRaw = false;
-
-      for (let i = 2; i < args.length; i++) {
-        if (args[i] === "--start" && args[i + 1] && args[i + 2] === "--end" && args[i + 3]) {
-          explicitPlaceholders.push({ start: parseInt(args[i + 1], 10), end: parseInt(args[i + 3], 10) });
-          i += 3;
-        } else if (args[i] === "--search" && args[i + 1]) {
-          searchStr = args[i + 1];
-          i++;
-        } else if (args[i] === "--length" && args[i + 1]) {
-          searchLength = parseInt(args[i + 1], 10);
-          i++;
-        } else if (args[i] === "--show-raw") {
-          showRaw = true;
-        }
-      }
-
-      if (explicitPlaceholders.length === 0 && !searchStr && !showRaw) {
-        console.error("Error: provide --start <n> --end <n> or --search <string>");
+      const mode = args[2] as string;
+      if (!mode || !["search", "range", "list", "clear", "remove", "replace", "show-raw"].includes(mode)) {
+        console.error("Error: mode required (search|range|list|clear|remove|replace|show-raw)");
+        console.error("Usage: set-placeholder <session-id> <mode> [args...]");
         process.exit(1);
       }
-
-      await cmdSetPlaceholder(args[1], explicitPlaceholders, showRaw, searchStr, searchLength);
+      const spArgs = args.slice(3);
+      await cmdSetPlaceholder(args[1], mode as any, spArgs);
       break;
     }
 
     case "set-payload": {
       if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
-      let list: string[] = [];
+      const payloadOpts: any = {};
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--list" && args[i + 1]) {
-          list = args[i + 1].split(",").map(s => s.trim());
+          payloadOpts.list = args[i + 1].split(",").map(s => s.trim());
           i++;
         }
+        else if (args[i] === "--json" && args[i + 1]) { payloadOpts.json = args[i + 1]; i++; }
+        else if (args[i] === "--index" && args[i + 1]) { payloadOpts.index = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--range" && args[i + 1]) { payloadOpts.range = args[i + 1]; i++; }
+        else if (args[i] === "--remove") { payloadOpts.remove = true; }
       }
-      if (list.length === 0) { console.error("Error: --list required (comma-separated)"); process.exit(1); }
-      await cmdSetPayload(args[1], list);
+      await cmdSetPayload(args[1], payloadOpts);
       break;
     }
 
@@ -840,6 +910,80 @@ async function main() {
       break;
     }
     case "auth-status": { await cmdAuthStatus(); break; }
+
+    // ── Composite Commands ──
+    case "idor-chain": {
+      if (!args[1] || !args[2]) { console.error("Error: idor-chain requires <base-request-id> --ids <comma-separated-ids>"); process.exit(1); }
+      const baseRequestId = args[1];
+      let idsStr: string | undefined;
+      let createFindings = false;
+      let findingTitlePrefix = "IDOR on";
+      let dedupeKeyPrefix = "idor";
+      let maxConcurrent = 3;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--ids" && args[i + 1]) { idsStr = args[i + 1]; i++; }
+        else if (args[i] === "--create-findings") { createFindings = true; }
+        else if (args[i] === "--finding-title-prefix" && args[i + 1]) { findingTitlePrefix = args[i + 1]; i++; }
+        else if (args[i] === "--dedupe-key-prefix" && args[i + 1]) { dedupeKeyPrefix = args[i + 1]; i++; }
+        else if (args[i] === "--max-concurrent" && args[i + 1]) { maxConcurrent = parseInt(args[i + 1], 10); i++; }
+      }
+      if (!idsStr) { console.error("Error: --ids required (comma-separated target IDs)"); process.exit(1); }
+      await cmdIdorChain(baseRequestId, idsStr.split(",").map(s => s.trim()), { createFindings, findingTitlePrefix, dedupeKeyPrefix, maxConcurrent });
+      break;
+    }
+
+    case "fuzz-automate": {
+      if (!args[1] || !args[2]) { console.error("Error: fuzz-automate requires <request-id> --payloads <comma-separated-payloads>"); process.exit(1); }
+      const requestId = args[1];
+      let payloadsStr: string | undefined;
+      let strategy: "ALL" | "SEQUENTIAL" | "PARALLEL" | "MATRIX" = "MATRIX";
+      let workers = 5;
+      let delay = 100;
+      let redirectStrategy: "NEVER" | "IN_SCOPE" | "SAME_SITE" | "ALWAYS" = "NEVER";
+      let followRedirects = false;
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--payloads" && args[i + 1]) { payloadsStr = args[i + 1]; i++; }
+        else if (args[i] === "--strategy" && args[i + 1]) { strategy = args[i + 1] as any; i++; }
+        else if (args[i] === "--workers" && args[i + 1]) { workers = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--delay" && args[i + 1]) { delay = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--redirect-strategy" && args[i + 1]) { redirectStrategy = args[i + 1] as any; i++; }
+        else if (args[i] === "--follow-redirects") { followRedirects = true; }
+      }
+      if (!payloadsStr) { console.error("Error: --payloads required (comma-separated)"); process.exit(1); }
+      await cmdFuzzAutomate(requestId, payloadsStr.split(",").map(s => s.trim()), { strategy, workers, delay, redirectStrategy, followRedirects });
+      break;
+    }
+
+    case "bulk-replay": {
+      let filter: string | undefined;
+      let collectionId: string | undefined;
+      let rateLimit = 10;
+      let maxRequests = 100;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--filter" && args[i + 1]) { filter = args[i + 1]; i++; }
+        else if (args[i] === "--collection" && args[i + 1]) { collectionId = args[i + 1]; i++; }
+        else if (args[i] === "--rate" && args[i + 1]) { rateLimit = parseInt(args[i + 1], 10); i++; }
+        else if (args[i] === "--max" && args[i + 1]) { maxRequests = parseInt(args[i + 1], 10); i++; }
+      }
+      if (!filter && !collectionId) { console.error("Error: --filter or --collection required"); process.exit(1); }
+      await cmdBulkReplay({ filter, collectionId, rateLimit, maxRequests });
+      break;
+    }
+
+    case "discover-auth": {
+      if (!args[1] || !args[2] || !args[3]) { console.error("Error: discover-auth requires <base-request-id> <search-pattern> --ids <comma-separated-ids>"); process.exit(1); }
+      const baseRequestId = args[1];
+      const searchPattern = args[2];
+      let idsStr: string | undefined;
+      let createFindings = false;
+      for (let i = 3; i < args.length; i++) {
+        if (args[i] === "--ids" && args[i + 1]) { idsStr = args[i + 1]; i++; }
+        else if (args[i] === "--create-findings") { createFindings = true; }
+      }
+      if (!idsStr) { console.error("Error: --ids required"); process.exit(1); }
+      await cmdDiscoverAuth(baseRequestId, searchPattern, idsStr.split(",").map(s => s.trim()), { createFindings });
+      break;
+    }
 
     default:
       console.error(`Unknown command: ${command}`);

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -156,8 +156,8 @@ Usage:
                                Clone an existing automate session
   set-placeholder <session-id>  Set injection points (placeholders)
     --start <n> --end <n>      Byte offsets in the raw request
-    --search <string>          Auto-locate string and show raw (dry-run)
-    --length <n>               Bytes to replace after search string
+    --search <string>          Search for string, placeholder covers the string
+    --length <n>               Legacy: bytes to cover after the search string
     --show-raw                 Display raw request content
   set-payload <session-id>     Set payload list
     --list "a,b,c"             Comma-separated payload values
@@ -568,7 +568,7 @@ async function main() {
       }
 
       if (explicitPlaceholders.length === 0 && !searchStr && !showRaw) {
-        console.error("Error: provide --start <n> --end <n> or --search <string> [--length <n>]");
+        console.error("Error: provide --start <n> --end <n> or --search <string>");
         process.exit(1);
       }
 

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -11,7 +11,7 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
 import { cmdReplay, cmdSendRaw, cmdEdit, cmdGetSession, cmdReplayEntries, cmdEditSession, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdMoveSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection } from "./lib/commands/replay";
 import type { ConnectionOverrides } from "./lib/commands/replay";
-import { cmdCreateAutomateSession, cmdFuzz, cmdRenameAutomateSession, cmdSetPlaceholder, cmdSetPayload, cmdAutomateResults, cmdAutomateSessions, cmdAutomateTasks, cmdDeleteAutomateSession, cmdDuplicateAutomateSession, cmdPauseAutomateTask, cmdResumeAutomateTask, cmdCancelAutomateTask, cmdRenameAutomateEntry, cmdDeleteAutomateEntries } from "./lib/commands/automate";
+import { cmdCreateAutomateSession, cmdFuzz, cmdRenameAutomateSession, cmdSetPlaceholder, cmdSetPayload, cmdAutomateResults, cmdAutomateSessions, cmdAutomateTasks, cmdDeleteAutomateSession, cmdDuplicateAutomateSession, cmdPauseAutomateTask, cmdResumeAutomateTask, cmdCancelAutomateTask, cmdRenameAutomateEntry, cmdDeleteAutomateEntries, cmdEditAutomateBody } from "./lib/commands/automate";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
@@ -173,6 +173,9 @@ Usage:
                                Rename an automate entry
   delete-automate-entries <ids>
                                Delete automate entries (comma-separated)
+  edit-automate-body <session-id>
+                               Find/replace in the raw request body
+    --replace <from>:::<to>    Replace text (repeatable)
 
 ═══════════════════════════════════════════════
  FINDINGS
@@ -653,6 +656,16 @@ async function main() {
     case "delete-automate-entries": {
       if (!args[1]) { console.error("Error: comma-separated entry IDs required"); process.exit(1); }
       await cmdDeleteAutomateEntries(args[1].split(",").map((s: string) => s.trim()));
+      break;
+    }
+
+    case "edit-automate-body": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      const replacements: string[] = [];
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--replace" && args[i + 1]) { replacements.push(args[i + 1]); i++; }
+      }
+      await cmdEditAutomateBody(args[1], replacements);
       break;
     }
 

--- a/skills/caido-mode/caido-client.ts
+++ b/skills/caido-mode/caido-client.ts
@@ -9,8 +9,9 @@ import { parseOutputOpts, DEFAULT_OUTPUT_OPTS } from "./lib/types";
 
 // Commands
 import { cmdSearch, cmdRecent, cmdGet, cmdGetResponse, cmdExportCurl } from "./lib/commands/requests";
-import { cmdReplay, cmdSendRaw, cmdEdit, cmdGetSession, cmdReplayEntries, cmdEditSession, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdMoveSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection, cmdCreateAutomateSession, cmdFuzz } from "./lib/commands/replay";
+import { cmdReplay, cmdSendRaw, cmdEdit, cmdGetSession, cmdReplayEntries, cmdEditSession, cmdReplaySessions, cmdCreateSession, cmdRenameSession, cmdMoveSession, cmdDeleteSessions, cmdReplayCollections, cmdCreateCollection, cmdRenameCollection, cmdDeleteCollection } from "./lib/commands/replay";
 import type { ConnectionOverrides } from "./lib/commands/replay";
+import { cmdCreateAutomateSession, cmdFuzz, cmdRenameAutomateSession, cmdSetPlaceholder, cmdSetPayload, cmdAutomateResults, cmdAutomateSessions, cmdAutomateTasks, cmdDeleteAutomateSession, cmdDuplicateAutomateSession, cmdPauseAutomateTask, cmdResumeAutomateTask, cmdCancelAutomateTask, cmdRenameAutomateEntry, cmdDeleteAutomateEntries } from "./lib/commands/automate";
 import { cmdFindings, cmdGetFinding, cmdCreateFinding, cmdUpdateFinding } from "./lib/commands/findings";
 import { cmdScopes, cmdCreateScope, cmdUpdateScope, cmdDeleteScope, cmdFilters, cmdCreateFilter, cmdUpdateFilter, cmdDeleteFilter, cmdEnvs, cmdCreateEnv, cmdSelectEnv, cmdEnvSet, cmdDeleteEnv, cmdProjects, cmdSelectProject, cmdHostedFiles, cmdDeleteHostedFile, cmdTasks, cmdCancelTask } from "./lib/commands/management";
 import { cmdInterceptStatus, cmdInterceptSet } from "./lib/commands/intercept";
@@ -146,7 +147,32 @@ Usage:
 ═══════════════════════════════════════════════
 
   create-automate-session <id> Create an automate session for fuzzing
-  fuzz <session-id>            Start fuzzing (configure payloads in Caido UI)
+  automate-sessions            List all automate sessions
+    --limit <n>                Max results (default: 20)
+  rename-automate-session <id> <name>
+                               Rename an automate session
+  delete-automate-session <id> Delete an automate session
+  duplicate-automate-session <id>
+                               Clone an existing automate session
+  set-placeholder <session-id>  Set injection points (placeholders)
+    --start <n> --end <n>      Byte offsets in the raw request
+    --search <string>          Auto-locate string and show raw (dry-run)
+    --length <n>               Bytes to replace after search string
+    --show-raw                 Display raw request content
+  set-payload <session-id>     Set payload list
+    --list "a,b,c"             Comma-separated payload values
+  fuzz <session-id>            Start fuzzing (must have placeholders + payloads)
+  automate-results <session-id>
+                               Get all fuzzing results (request/response pairs)
+  automate-tasks               List automate tasks
+    --limit <n>                Max results (default: 20)
+  pause-task <id>              Pause a running automate task
+  resume-task <id>             Resume a paused automate task
+  cancel-task-automate <id>    Cancel a running automate task
+  rename-automate-entry <id> <name>
+                               Rename an automate entry
+  delete-automate-entries <ids>
+                               Delete automate entries (comma-separated)
 
 ═══════════════════════════════════════════════
  FINDINGS
@@ -508,7 +534,125 @@ async function main() {
 
     case "fuzz": {
       if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
-      await cmdFuzz(args[1], []);
+      await cmdFuzz(args[1]);
+      break;
+    }
+
+    case "rename-automate-session": {
+      if (!args[1] || !args[2]) { console.error("Error: session-id and name required"); process.exit(1); }
+      await cmdRenameAutomateSession(args[1], args[2]);
+      break;
+    }
+
+    case "set-placeholder": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+
+      const explicitPlaceholders: { start: number; end: number }[] = [];
+      let searchStr: string | undefined;
+      let searchLength: number | undefined;
+      let showRaw = false;
+
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--start" && args[i + 1] && args[i + 2] === "--end" && args[i + 3]) {
+          explicitPlaceholders.push({ start: parseInt(args[i + 1], 10), end: parseInt(args[i + 3], 10) });
+          i += 3;
+        } else if (args[i] === "--search" && args[i + 1]) {
+          searchStr = args[i + 1];
+          i++;
+        } else if (args[i] === "--length" && args[i + 1]) {
+          searchLength = parseInt(args[i + 1], 10);
+          i++;
+        } else if (args[i] === "--show-raw") {
+          showRaw = true;
+        }
+      }
+
+      if (explicitPlaceholders.length === 0 && !searchStr && !showRaw) {
+        console.error("Error: provide --start <n> --end <n> or --search <string> [--length <n>]");
+        process.exit(1);
+      }
+
+      await cmdSetPlaceholder(args[1], explicitPlaceholders, showRaw, searchStr, searchLength);
+      break;
+    }
+
+    case "set-payload": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      let list: string[] = [];
+      for (let i = 2; i < args.length; i++) {
+        if (args[i] === "--list" && args[i + 1]) {
+          list = args[i + 1].split(",").map(s => s.trim());
+          i++;
+        }
+      }
+      if (list.length === 0) { console.error("Error: --list required (comma-separated)"); process.exit(1); }
+      await cmdSetPayload(args[1], list);
+      break;
+    }
+
+    case "automate-results": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      await cmdAutomateResults(args[1]);
+      break;
+    }
+
+    case "automate-sessions": {
+      let limit = 20;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
+      }
+      await cmdAutomateSessions(limit);
+      break;
+    }
+
+    case "automate-tasks": {
+      let limit = 20;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--limit" && args[i + 1]) { limit = parseInt(args[i + 1], 10); i++; }
+      }
+      await cmdAutomateTasks(limit);
+      break;
+    }
+
+    case "delete-automate-session": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      await cmdDeleteAutomateSession(args[1]);
+      break;
+    }
+
+    case "duplicate-automate-session": {
+      if (!args[1]) { console.error("Error: session-id required"); process.exit(1); }
+      await cmdDuplicateAutomateSession(args[1]);
+      break;
+    }
+
+    case "pause-task": {
+      if (!args[1]) { console.error("Error: task-id required"); process.exit(1); }
+      await cmdPauseAutomateTask(args[1]);
+      break;
+    }
+
+    case "resume-task": {
+      if (!args[1]) { console.error("Error: task-id required"); process.exit(1); }
+      await cmdResumeAutomateTask(args[1]);
+      break;
+    }
+
+    case "cancel-task-automate": {
+      if (!args[1]) { console.error("Error: task-id required"); process.exit(1); }
+      await cmdCancelAutomateTask(args[1]);
+      break;
+    }
+
+    case "rename-automate-entry": {
+      if (!args[1] || !args[2]) { console.error("Error: entry-id and name required"); process.exit(1); }
+      await cmdRenameAutomateEntry(args[1], args[2]);
+      break;
+    }
+
+    case "delete-automate-entries": {
+      if (!args[1]) { console.error("Error: comma-separated entry IDs required"); process.exit(1); }
+      await cmdDeleteAutomateEntries(args[1].split(",").map((s: string) => s.trim()));
       break;
     }
 

--- a/skills/caido-mode/lib/commands/automate.ts
+++ b/skills/caido-mode/lib/commands/automate.ts
@@ -1,5 +1,12 @@
 /**
- * Automate / Fuzz commands — rename, placeholders, payloads, results.
+ * Automate / Fuzz commands — create, edit, placeholders, payloads, results.
+ *
+ * Workflow:
+ *   1. create-automate-session <request-id> [--name] [--strategy] [--strategy-options]
+ *   2. edit-automate-session <id> --replace 'old:::FUZZ' [--name] [--strategy]
+ *   3. set-placeholder <id> search FUZZ
+ *   4. set-payload <id> --add-set --index 0 --list "a,b,c"
+ *   5. fuzz <id>
  */
 import { getClient } from "../client";
 import {
@@ -20,19 +27,717 @@ import {
   DELETE_AUTOMATE_ENTRIES,
 } from "../graphql";
 
-interface PlaceholderInput {
+// ── Types ──
+
+export interface PlaceholderInput {
   start: number;
   end: number;
 }
 
+export interface PayloadSet {
+  index: number;
+  type: "simpleList" | "number";
+  list?: string[];
+  range?: { min: number; max: number; step?: number };
+  preprocessors?: string[];
+}
+
+export interface EditAutomateOpts {
+  name?: string;
+  strategy?: "ALL" | "SEQUENTIAL" | "PARALLEL" | "MATRIX";
+  strategyOptions?: string; // JSON string
+  replacements?: string[];
+  setHeaders?: string[];
+  removeHeaders?: string[];
+  body?: string;
+  method?: string;
+  path?: string;
+}
+
+export interface SetPayloadOpts {
+  list?: string[];
+  json?: string; // @file path or inline JSON
+  index?: number;
+  range?: string; // "min-max" or "min-max:step"
+  remove?: boolean;
+}
+
+// ── Helpers ──
+
+/** Resolve @file arg — if string starts with @, read file contents; otherwise return as-is */
+function resolveFileArg(value: string): string {
+  if (value.startsWith("@")) {
+    const fs = require("fs");
+    const filePath = value.slice(1);
+    return fs.readFileSync(filePath, "utf-8");
+  }
+  return value;
+}
+
+/** Read existing session, exit on error */
+async function getSession(sessionId: string) {
+  const client = await getClient();
+  const result = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const session = (result as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+  return { client, session };
+}
+
+/** Read existing settings preserving everything except what we're changing */
+function buildCompleteSettings(
+  existingSettings: any,
+  overrides: {
+    payloads?: any[];
+    placeholders?: any[];
+    strategy?: string;
+    redirect?: any;
+    concurrency?: any;
+  } = {},
+) {
+  const settings = {
+    payloads: overrides.payloads ?? existingSettings?.payloads ?? [],
+    placeholders: overrides.placeholders ?? existingSettings?.placeholders ?? [],
+    redirect: overrides.redirect ?? existingSettings?.redirect ?? { strategy: "ALWAYS", max: 5 },
+    strategy: overrides.strategy ?? existingSettings?.strategy ?? "ALL",
+    concurrency: overrides.concurrency ?? existingSettings?.concurrency ?? { workers: 1, delay: 0 },
+    retryOnFailure: existingSettings?.retryOnFailure ?? { maximumRetries: 0, backoff: 0 },
+    closeConnection: existingSettings?.closeConnection ?? false,
+    updateContentLength: true,
+  };
+  return settings;
+}
+
+/** Normalise payload from SDK format to our internal format */
+function normalisePayloads(payloads: any[]): any[] {
+  if (!payloads?.length) return [];
+  return payloads.map((p: any) => {
+    const opts: any = {};
+    if (p.options?.list) opts.simpleList = { list: p.options.list };
+    else if (p.options?.simpleList) opts.simpleList = p.options.simpleList;
+    else if (p.options?.range) opts.number = { range: p.options.range, increments: p.options.increments, minLength: p.options.minLength };
+    else if (p.options?.number) opts.number = p.options.number;
+    else opts.simpleList = { list: [] };
+    return { options: opts, preprocessors: p.preprocessors ?? [] };
+  });
+}
+
+/** Normalise placeholders from SDK format */
+function normalisePlaceholders(placeholders: any[]): PlaceholderInput[] {
+  if (!placeholders?.length) return [];
+  return placeholders.map((p: any) => ({ start: p.start, end: p.end }));
+}
+
+/** Validate PARALLEL/MATRIX strategies against placeholder and payload counts */
+function validateStrategyPayloads(strategy: string, payloads: any[], placeholderCount: number) {
+  if (strategy !== "PARALLEL" && strategy !== "MATRIX") return;
+
+  // Both PARALLEL and MATRIX require one payload set per placeholder
+  if (placeholderCount > 0 && payloads.length !== placeholderCount) {
+    console.error(JSON.stringify({
+      error: `${strategy} requires one payload set per placeholder. Have ${placeholderCount} placeholder(s) but ${payloads.length} payload set(s). Use 'set-payload --add-set --index N ...' to add sets.`,
+      placeholders: placeholderCount,
+      payloadSets: payloads.length,
+    }, null, 2));
+    process.exit(1);
+  }
+
+  // PARALLEL additionally requires all sets to be the same length
+  if (strategy === "PARALLEL" && payloads.length >= 2) {
+    const lengths = payloads.map((p: any) => {
+      if (p.options?.simpleList?.list) return p.options.simpleList.list.length;
+      if (p.options?.number?.range) {
+        const r = p.options.number.range;
+        const step = p.options.number.increments ?? 1;
+        return Math.floor((r.max - r.min) / step) + 1;
+      }
+      return 0;
+    });
+
+    const first = lengths[0];
+    const mismatched = lengths.findIndex((l: number) => l !== first);
+    if (mismatched !== -1) {
+      console.error(JSON.stringify({
+        error: `PARALLEL strategy requires all payload sets to be the same length. Set 0 has ${first} items but set ${mismatched} has ${lengths[mismatched]} items.`,
+        lengths,
+      }, null, 2));
+      process.exit(1);
+    }
+  }
+}
+
 // ── Create automate session ──
 
-export async function cmdCreateAutomateSession(requestId: string) {
+export async function cmdCreateAutomateSession(
+  requestId: string,
+  name?: string,
+  strategy?: string,
+  strategyOptions?: string,
+) {
   const client = await getClient();
   const result = await client.graphql.mutation(CREATE_AUTOMATE_SESSION, {
     input: { requestSource: { id: requestId } },
   });
-  console.log(JSON.stringify((result as any).createAutomateSession.session, null, 2));
+  const session = (result as any).createAutomateSession.session;
+  const sessionId = session.id;
+
+  // If name/strategy/strategyOptions provided, apply via UPDATE
+  if (name || strategy || strategyOptions) {
+    const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+    const fullSession = (getResult as any).automateSession;
+
+    const overrides: any = {};
+    if (strategy) overrides.strategy = strategy;
+
+    let parsedOptions: any = {};
+    if (strategyOptions) {
+      const soContent = resolveFileArg(strategyOptions);
+      try { parsedOptions = JSON.parse(soContent); } catch {
+        console.error("Error: --strategy-options must be valid JSON (or @file pointing to JSON)");
+        process.exit(1);
+      }
+    }
+
+    const settings = buildCompleteSettings(fullSession.settings, overrides);
+
+    // Apply strategy options
+    if (parsedOptions.redirectStrategy || parsedOptions.followRedirects !== undefined) {
+      settings.redirect = {
+        strategy: parsedOptions.redirectStrategy ?? settings.redirect.strategy,
+        max: parsedOptions.redirectMax ?? settings.redirect.max ?? 5,
+      };
+    }
+    if (parsedOptions.workers !== undefined || parsedOptions.delay !== undefined) {
+      settings.concurrency = {
+        workers: parsedOptions.workers ?? settings.concurrency.workers,
+        delay: parsedOptions.delay ?? settings.concurrency.delay,
+      };
+    }
+
+    await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+      id: sessionId,
+      input: {
+        connection: fullSession.connection,
+        raw: fullSession.raw,
+        name: name ?? fullSession.name,
+        settings,
+      },
+    });
+  }
+
+  console.log(JSON.stringify({
+    sessionId,
+    name: name ?? session.name,
+    strategy: strategy ?? "ALL",
+    ...(Object.keys(parsedOptions).length ? { strategyOptions: parsedOptions } : {}),
+  }, null, 2));
+}
+
+// ── Edit automate session (unified) ──
+
+export async function cmdEditAutomateSession(sessionId: string, opts: EditAutomateOpts) {
+  const { client, session } = await getSession(sessionId);
+  if (!session.raw) {
+    console.error("No raw request data in session");
+    process.exit(1);
+  }
+
+  let raw = Buffer.from(session.raw, "base64").toString("utf-8");
+  const existingSettings = session.settings as any;
+  let modified = false;
+
+  // Apply body replacements
+  if (opts.replacements?.length) {
+    for (const rep of opts.replacements) {
+      const [from, to] = rep.split(":::");
+      if (from !== undefined && to !== undefined) {
+        raw = raw.replaceAll(from, to);
+      }
+    }
+    modified = true;
+  }
+
+  // Apply method change
+  if (opts.method) {
+    const firstLine = raw.split("\r\n")[0];
+    const parts = firstLine.split(" ");
+    if (parts.length >= 3) {
+      parts[0] = opts.method.toUpperCase();
+      raw = parts.join(" ") + raw.substring(firstLine.length);
+      modified = true;
+    }
+  }
+
+  // Apply path change
+  if (opts.path) {
+    const firstLine = raw.split("\r\n")[0];
+    const parts = firstLine.split(" ");
+    if (parts.length >= 3) {
+      parts[1] = opts.path;
+      raw = parts.join(" ") + raw.substring(firstLine.length);
+      modified = true;
+    }
+  }
+
+  // Apply header changes
+  if (opts.setHeaders?.length || opts.removeHeaders?.length) {
+    const lineEnd = "\r\n";
+    const separator = lineEnd + lineEnd;
+    const parts = raw.split(separator);
+    const headerLines = parts[0].split(lineEnd);
+    const bodyPart = parts.slice(1).join(separator);
+
+    let newHeaders = [...headerLines];
+
+    // Remove headers
+    if (opts.removeHeaders?.length) {
+      for (const rmHeader of opts.removeHeaders) {
+        const lower = rmHeader.toLowerCase();
+        newHeaders = newHeaders.filter(h => !h.toLowerCase().startsWith(lower + ":"));
+      }
+    }
+
+    // Set headers
+    if (opts.setHeaders?.length) {
+      for (const setHeader of opts.setHeaders) {
+        const colonIdx = setHeader.indexOf(":");
+        if (colonIdx === -1) continue;
+        const name = setHeader.substring(0, colonIdx).toLowerCase();
+        newHeaders = newHeaders.filter(h => !h.toLowerCase().startsWith(name + ":"));
+        newHeaders.push(setHeader);
+      }
+    }
+
+    raw = newHeaders.join(lineEnd) + separator + bodyPart;
+    modified = true;
+  }
+
+  // Apply full body replacement (@file supported)
+  if (opts.body !== undefined) {
+    const bodyContent = resolveFileArg(opts.body);
+    const lineEnd = "\r\n";
+    const separator = lineEnd + lineEnd;
+    const parts = raw.split(separator);
+    raw = parts[0] + separator + bodyContent;
+    modified = true;
+  }
+
+  // Recompute Content-Length if body changed
+  if (modified) {
+    const lineEnd = "\r\n";
+    const separator = lineEnd + lineEnd;
+    const parts = raw.split(separator);
+    if (parts.length >= 2) {
+      const headerBlock = parts[0];
+      const bodyPart = parts.slice(1).join(separator);
+      const headerLines = headerBlock.split(lineEnd);
+      const clBytes = new TextEncoder().encode(bodyPart).length;
+      const newHeaders = headerLines.filter(h => !h.toLowerCase().startsWith("content-length:"));
+      newHeaders.push(`Content-Length: ${clBytes}`);
+      raw = newHeaders.join(lineEnd) + separator + bodyPart;
+    }
+  }
+
+  const newBase64 = Buffer.from(raw, "utf-8").toString("base64");
+
+  // Build strategy settings
+  let strategy = existingSettings?.strategy ?? "ALL";
+  if (opts.strategy) strategy = opts.strategy;
+
+  let parsedOptions: any = {};
+  if (opts.strategyOptions) {
+    const soContent = resolveFileArg(opts.strategyOptions);
+    try { parsedOptions = JSON.parse(soContent); } catch {
+      console.error("Error: --strategy-options must be valid JSON (or @file pointing to JSON)");
+      process.exit(1);
+    }
+  }
+
+  const settings = buildCompleteSettings(existingSettings, { strategy });
+
+  if (parsedOptions.redirectStrategy || parsedOptions.followRedirects !== undefined) {
+    settings.redirect = {
+      strategy: parsedOptions.redirectStrategy ?? settings.redirect.strategy,
+      max: parsedOptions.redirectMax ?? settings.redirect.max ?? 5,
+    };
+  }
+  if (parsedOptions.workers !== undefined || parsedOptions.delay !== undefined) {
+    settings.concurrency = {
+      workers: parsedOptions.workers ?? settings.concurrency.workers,
+      delay: parsedOptions.delay ?? settings.concurrency.delay,
+    };
+  }
+
+  // Normalise existing payloads to SDK format
+  settings.payloads = normalisePayloads(settings.payloads);
+  settings.placeholders = normalisePlaceholders(settings.placeholders);
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+    id: sessionId,
+    input: {
+      connection: session.connection,
+      raw: modified ? newBase64 : session.raw,
+      name: opts.name ?? session.name,
+      settings,
+    },
+  });
+
+  console.log(JSON.stringify({
+    sessionId,
+    name: opts.name ?? session.name,
+    strategy,
+    modified,
+    ...(opts.replacements?.length ? { replacements: opts.replacements.length } : {}),
+  }, null, 2));
+}
+
+// ── Set placeholder (mode-based) ──
+
+export async function cmdSetPlaceholder(
+  sessionId: string,
+  mode: "search" | "range" | "list" | "clear" | "remove" | "replace" | "show-raw",
+  args: string[],
+) {
+  const { client, session } = await getSession(sessionId);
+  if (!session.raw) {
+    console.error("No raw request data in session");
+    process.exit(1);
+  }
+
+  const raw = Buffer.from(session.raw, "base64").toString("utf-8");
+  const existingSettings = session.settings as any;
+  let placeholders: PlaceholderInput[] = normalisePlaceholders(existingSettings?.placeholders ?? []);
+
+  switch (mode) {
+    case "show-raw": {
+      const escaped = raw.replace(/\r\n/g, "\\r\\n");
+      const lines = raw.split("\r\n");
+      let pos = 0;
+      const lineMap: { start: number; end: number; content: string }[] = [];
+      for (const line of lines) {
+        lineMap.push({ start: pos, end: pos + line.length, content: line });
+        pos += line.length + 2;
+      }
+      console.log(JSON.stringify({
+        raw: escaped,
+        length: raw.length,
+        lines: lineMap,
+        placeholders,
+      }, null, 2));
+      return;
+    }
+
+    case "search": {
+      if (!args[0]) { console.error("Error: search requires <pattern>"); process.exit(1); }
+      const pattern = args[0];
+      let count: number | undefined;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === "--count" && args[i + 1]) { count = parseInt(args[i + 1], 10); i++; }
+      }
+
+      const found: PlaceholderInput[] = [];
+      let searchPos = 0;
+      while (true) {
+        const idx = raw.indexOf(pattern, searchPos);
+        if (idx === -1) break;
+        found.push({ start: idx, end: idx + pattern.length });
+        searchPos = idx + pattern.length;
+        if (count !== undefined && found.length >= count) break;
+      }
+
+      if (found.length === 0) {
+        console.error(`Pattern "${pattern}" not found in raw request`);
+        process.exit(1);
+      }
+
+      // Replace ALL placeholders with search results
+      placeholders = found;
+      console.log(JSON.stringify({
+        note: `Found ${found.length} occurrence(s) of "${pattern}"`,
+        placeholders: found,
+      }, null, 2));
+      break;
+    }
+
+    case "range": {
+      if (!args[0] || !args[1]) { console.error("Error: range requires <start> <end>"); process.exit(1); }
+      const start = parseInt(args[0], 10);
+      const end = parseInt(args[1], 10);
+      if (isNaN(start) || isNaN(end) || start >= end) {
+        console.error("Error: invalid range (start must be < end)");
+        process.exit(1);
+      }
+      // Replace ALL placeholders with single range
+      placeholders = [{ start, end }];
+      console.log(JSON.stringify({ placeholders }, null, 2));
+      break;
+    }
+
+    case "list": {
+      if (!args.length) { console.error("Error: list requires <start:end> arguments"); process.exit(1); }
+      const parsed: PlaceholderInput[] = [];
+      for (const arg of args) {
+        const parts = arg.split(":");
+        if (parts.length !== 2) {
+          console.error(`Error: invalid range "${arg}" — expected start:end`);
+          process.exit(1);
+        }
+        const start = parseInt(parts[0], 10);
+        const end = parseInt(parts[1], 10);
+        if (isNaN(start) || isNaN(end) || start >= end) {
+          console.error(`Error: invalid range "${arg}"`);
+          process.exit(1);
+        }
+        parsed.push({ start, end });
+      }
+      // Replace ALL placeholders with explicit list
+      placeholders = parsed;
+      console.log(JSON.stringify({ placeholders }, null, 2));
+      break;
+    }
+
+    case "clear": {
+      placeholders = [];
+      console.log(JSON.stringify({ note: "All placeholders cleared", placeholders: [] }, null, 2));
+      break;
+    }
+
+    case "remove": {
+      if (!args[0]) { console.error("Error: remove requires <index>"); process.exit(1); }
+      const idx = parseInt(args[0], 10);
+      if (isNaN(idx) || idx < 0 || idx >= placeholders.length) {
+        console.error(`Error: index ${idx} out of range (0-${placeholders.length - 1})`);
+        process.exit(1);
+      }
+      const removed = placeholders.splice(idx, 1);
+      console.log(JSON.stringify({
+        note: `Removed placeholder at index ${idx}`,
+        removed: removed[0],
+        remaining: placeholders.length,
+        placeholders,
+      }, null, 2));
+      break;
+    }
+
+    case "replace": {
+      if (!args[0] || !args[1] || !args[2]) { console.error("Error: replace requires <index> <start> <end>"); process.exit(1); }
+      const idx = parseInt(args[0], 10);
+      const start = parseInt(args[1], 10);
+      const end = parseInt(args[2], 10);
+      if (isNaN(idx) || idx < 0 || idx >= placeholders.length) {
+        console.error(`Error: index ${idx} out of range (0-${placeholders.length - 1})`);
+        process.exit(1);
+      }
+      if (isNaN(start) || isNaN(end) || start >= end) {
+        console.error("Error: invalid range (start must be < end)");
+        process.exit(1);
+      }
+      const old = { ...placeholders[idx] };
+      placeholders[idx] = { start, end };
+      console.log(JSON.stringify({
+        note: `Replaced placeholder ${idx}`,
+        old,
+        new: placeholders[idx],
+        placeholders,
+      }, null, 2));
+      break;
+    }
+  }
+
+  // Write back updated placeholders (preserving payloads)
+  const settings = buildCompleteSettings(existingSettings);
+  settings.payloads = normalisePayloads(settings.payloads);
+  settings.placeholders = placeholders;
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+    id: sessionId,
+    input: {
+      connection: session.connection,
+      raw: session.raw,
+      settings,
+    },
+  });
+
+  console.log(JSON.stringify({
+    sessionId,
+    placeholdersSet: placeholders.length,
+    placeholders,
+    updated: true,
+  }, null, 2));
+}
+
+// ── Set payload (extended) ──
+
+export async function cmdSetPayload(sessionId: string, opts: SetPayloadOpts) {
+  const { client, session } = await getSession(sessionId);
+  const existingSettings = session.settings as any;
+  let payloads: any[] = normalisePayloads(existingSettings?.payloads ?? []);
+
+  // Mode: --json (full config from file or inline)
+  if (opts.json) {
+    const jsonContent = resolveFileArg(opts.json);
+
+    let config: any;
+    try { config = JSON.parse(jsonContent); } catch (e: any) {
+      console.error(`Error: invalid JSON: ${e.message}`);
+      process.exit(1);
+    }
+
+    if (config.payloads?.length) {
+      payloads = config.payloads.map((p: PayloadSet) => {
+        if (p.type === "number" && p.range) {
+          return {
+            options: { number: { range: { min: p.range.min, max: p.range.max }, increments: p.range.step ?? 1 } },
+            preprocessors: p.preprocessors ?? [],
+          };
+        }
+        return {
+          options: { simpleList: { list: p.list ?? [] } },
+          preprocessors: p.preprocessors ?? [],
+        };
+      });
+    }
+
+    if (config.strategy) {
+      // Apply strategy from JSON too
+      const settings = buildCompleteSettings(existingSettings, { strategy: config.strategy, payloads });
+      settings.placeholders = normalisePlaceholders(settings.placeholders);
+
+      if (config.strategyOptions) {
+        if (config.strategyOptions.redirectStrategy) {
+          settings.redirect = { strategy: config.strategyOptions.redirectStrategy, max: config.strategyOptions.redirectMax ?? 5 };
+        }
+        if (config.strategyOptions.workers !== undefined || config.strategyOptions.delay !== undefined) {
+          settings.concurrency = {
+            workers: config.strategyOptions.workers ?? settings.concurrency.workers,
+            delay: config.strategyOptions.delay ?? settings.concurrency.delay,
+          };
+        }
+      }
+
+      validateStrategyPayloads(settings.strategy, payloads, settings.placeholders.length);
+
+      await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+        id: sessionId,
+        input: { connection: session.connection, raw: session.raw, settings },
+      });
+
+      console.log(JSON.stringify({
+        sessionId,
+        strategy: settings.strategy,
+        payloadSets: payloads.length,
+        totalPayloads: payloads.reduce((a: number, p: any) => a + (p.options?.simpleList?.list?.length ?? 0), 0),
+        updated: true,
+      }, null, 2));
+      return;
+    }
+
+    // Just payloads, no strategy override
+    const settings = buildCompleteSettings(existingSettings, { payloads });
+    settings.placeholders = normalisePlaceholders(settings.placeholders);
+
+    validateStrategyPayloads(settings.strategy, payloads, settings.placeholders.length);
+
+    await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+      id: sessionId,
+      input: { connection: session.connection, raw: session.raw, settings },
+    });
+
+    console.log(JSON.stringify({
+      sessionId,
+      payloadSets: payloads.length,
+      totalPayloads: payloads.reduce((a: number, p: any) => a + (p.options?.simpleList?.list?.length ?? 0), 0),
+      updated: true,
+    }, null, 2));
+    return;
+  }
+
+  // Mode: --index N --remove
+  if (opts.index !== undefined && opts.remove) {
+    if (opts.index < 0 || opts.index >= payloads.length) {
+      console.error(`Error: index ${opts.index} out of range (0-${payloads.length - 1})`);
+      process.exit(1);
+    }
+    payloads.splice(opts.index, 1);
+  }
+  // Mode: --index N --list/range (add or replace at index)
+  else if (opts.index !== undefined && (opts.list?.length || opts.range)) {
+    const entry = buildPayloadEntry(opts);
+    if (opts.index >= payloads.length) {
+      // Pad with empty sets up to index
+      while (payloads.length < opts.index) {
+        payloads.push({ options: { simpleList: { list: [] } }, preprocessors: [] });
+      }
+      payloads.push(entry);
+    } else {
+      payloads[opts.index] = entry;
+    }
+  }
+  // Mode: --list (no index — backward compat, replaces all with single set)
+  else if (opts.list?.length) {
+    // Guard: bare --list with a multi-set strategy is almost certainly a mistake
+    const currentStrategy = existingSettings?.strategy ?? "ALL";
+    if (currentStrategy === "PARALLEL" || currentStrategy === "MATRIX") {
+      console.error(JSON.stringify({
+        error: `--list without --index replaces ALL payload sets with a single set. Use --index N --list "..." to set a payload for each placeholder when strategy is ${currentStrategy}.`,
+      }, null, 2));
+      process.exit(1);
+    }
+    payloads = [{
+      options: { simpleList: { list: opts.list } },
+      preprocessors: [],
+    }];
+  }
+  else {
+    console.error("Error: provide --list, --range, --json, or --index N --remove");
+    process.exit(1);
+  }
+
+  const settings = buildCompleteSettings(existingSettings, { payloads });
+  settings.placeholders = normalisePlaceholders(settings.placeholders);
+
+  validateStrategyPayloads(settings.strategy, payloads, settings.placeholders.length);
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+    id: sessionId,
+    input: { connection: session.connection, raw: session.raw, settings },
+  });
+
+  console.log(JSON.stringify({
+    sessionId,
+    payloadSets: payloads.length,
+    updated: true,
+  }, null, 2));
+}
+
+/** Build a single payload entry from opts (--list or --range) */
+function buildPayloadEntry(opts: SetPayloadOpts): any {
+  if (opts.range) {
+    // Format: "min-max" or "min-max:step"
+    const rangeParts = opts.range.split(":");
+    const step = rangeParts[1] ? Number(rangeParts[1]) : 1;
+    const bounds = rangeParts[0].split("-").map(Number);
+    const min = bounds[0];
+    const max = bounds[1];
+    if (isNaN(min) || isNaN(max) || min >= max) {
+      console.error(`Error: invalid range "${opts.range}" — expected "min-max" or "min-max:step"`);
+      process.exit(1);
+    }
+    return {
+      options: { number: { range: { min, max }, increments: step } },
+      preprocessors: [],
+    };
+  }
+  if (opts.list?.length) {
+    return {
+      options: { simpleList: { list: opts.list } },
+      preprocessors: [],
+    };
+  }
+  console.error("Error: --index requires --list or --range");
+  process.exit(1);
 }
 
 // ── Fuzz ──
@@ -59,171 +764,6 @@ export async function cmdFuzz(sessionId: string) {
     sessionId,
     taskId: task.id,
     status: "started",
-  }, null, 2));
-}
-
-// ── Rename automate session ──
-
-export async function cmdRenameAutomateSession(sessionId: string, name: string) {
-  const client = await getClient();
-  const result = await client.graphql.mutation(RENAME_AUTOMATE_SESSION, {
-    id: sessionId,
-    name,
-  });
-  console.log(JSON.stringify((result as any).renameAutomateSession.session, null, 2));
-}
-
-// ── Set placeholder (injection point) ──
-
-export async function cmdSetPlaceholder(
-  sessionId: string,
-  placeholders: PlaceholderInput[],
-  showRaw: boolean,
-  searchStr?: string,
-  searchLength?: number,
-) {
-  const client = await getClient();
-
-  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
-  const session = (getResult as any).automateSession;
-  if (!session) {
-    console.error(`Automate session ${sessionId} not found`);
-    process.exit(1);
-  }
-
-  if (!session.raw) {
-    console.error("No raw request data in session");
-    process.exit(1);
-  }
-
-  const raw = Buffer.from(session.raw, "base64").toString("utf-8");
-
-  // Auto-compute placeholder from --search
-  // Two modes:
-  //   --search <str>          : placeholder covers the found string
-  //   --search <str> --len <n>: placeholder covers n bytes after the string
-  if (searchStr && placeholders.length === 0) {
-    const idx = raw.indexOf(searchStr);
-    if (idx === -1) {
-      console.error(`Search string not found in raw request: "${searchStr}"`);
-      showRaw = true;
-    } else {
-      let start: number, end: number;
-      if (searchLength !== undefined) {
-        // Legacy mode: cover N bytes after the search string
-        start = idx + searchStr.length;
-        end = start + searchLength;
-      } else {
-        // Default mode: cover the search string itself
-        start = idx;
-        end = idx + searchStr.length;
-      }
-      placeholders.push({ start, end });
-      console.log(JSON.stringify({
-        note: `Found "${searchStr}" at byte ${idx}, setting placeholder at [${start}-${end}]`,
-      }, null, 2));
-    }
-  }
-
-  if (showRaw) {
-    const escaped = raw.replace(/\r\n/g, "\\r\\n");
-    console.log(JSON.stringify({ raw: escaped }, null, 2));
-    const lines = raw.split("\r\n");
-    let pos = 0;
-    for (const line of lines) {
-      console.log(`  [${pos}-${pos + line.length}] ${line}`);
-      pos += line.length + 2;
-    }
-  }
-
-  if (placeholders.length === 0) {
-    return;
-  }
-
-  // Preserve existing payloads when setting placeholders
-  const existingSettings = session.settings as any;
-  let existingPayloads: any[] = [];
-  if (existingSettings?.payloads?.length > 0) {
-    existingPayloads = existingSettings.payloads.map((p: any) => {
-      const opts: any = {};
-      if (p.options?.list) opts.simpleList = { list: p.options.list };
-      else if (p.options?.range) opts.number = { range: p.options.range, increments: p.options.increments, minLength: p.options.minLength };
-      else opts.simpleList = { list: [] };
-      return { options: opts, preprocessors: [] };
-    });
-  }
-
-  const input: any = {
-    connection: session.connection,
-    raw: session.raw,
-    settings: {
-      payloads: existingPayloads,
-      placeholders: placeholders.map(p => ({ start: p.start, end: p.end })),
-      redirect: { strategy: "ALWAYS", max: 5 },
-      strategy: "ALL",
-      concurrency: { workers: 1, delay: 0 },
-      retryOnFailure: { maximumRetries: 0, backoff: 0 },
-      closeConnection: false,
-      updateContentLength: true,
-    },
-  };
-
-  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, { id: sessionId, input });
-
-  console.log(JSON.stringify({
-    sessionId,
-    placeholdersSet: placeholders.length,
-    placeholders,
-    updated: true,
-  }, null, 2));
-}
-
-// ── Set payload list ──
-
-export async function cmdSetPayload(sessionId: string, list: string[]) {
-  const client = await getClient();
-
-  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
-  const session = (getResult as any).automateSession;
-  if (!session) {
-    console.error(`Automate session ${sessionId} not found`);
-    process.exit(1);
-  }
-
-  // Preserve existing placeholders when setting payloads
-  const existingSettings = session.settings as any;
-  let existingPlaceholders: { start: number; end: number }[] = [];
-  if (existingSettings?.placeholders?.length > 0) {
-    existingPlaceholders = existingSettings.placeholders.map((p: any) => ({ start: p.start, end: p.end }));
-  }
-
-  const input: any = {
-    connection: session.connection,
-    raw: session.raw,
-    settings: {
-      payloads: [
-        {
-          options: { simpleList: { list } },
-          preprocessors: [],
-        },
-      ],
-      placeholders: existingPlaceholders,
-      redirect: { strategy: "ALWAYS", max: 5 },
-      strategy: "ALL",
-      concurrency: { workers: 1, delay: 0 },
-      retryOnFailure: { maximumRetries: 0, backoff: 0 },
-      closeConnection: false,
-      updateContentLength: true,
-    },
-  };
-
-  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, { id: sessionId, input });
-
-  console.log(JSON.stringify({
-    sessionId,
-    payloadsSet: list.length,
-    payloads: list,
-    updated: true,
   }, null, 2));
 }
 
@@ -390,92 +930,4 @@ export async function cmdDeleteAutomateEntries(ids: string[]) {
   const client = await getClient();
   const result = await client.graphql.mutation(DELETE_AUTOMATE_ENTRIES, { ids });
   console.log(JSON.stringify((result as any).deleteAutomateEntries, null, 2));
-}
-
-// ── Edit automate session body ──
-// Find/replace in the raw request body, update Content-Length
-
-export async function cmdEditAutomateBody(sessionId: string, replacements: string[]) {
-  if (replacements.length === 0) {
-    console.error("Error: --replace <from>:::<to> is required");
-    process.exit(1);
-  }
-
-  const client = await getClient();
-
-  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
-  const session = (getResult as any).automateSession;
-  if (!session) {
-    console.error(`Automate session ${sessionId} not found`);
-    process.exit(1);
-  }
-
-  let raw = Buffer.from(session.raw, "base64").toString("utf-8");
-  const oldRaw = raw;
-
-  for (const rep of replacements) {
-    const [from, to] = rep.split(":::");
-    if (from !== undefined && to !== undefined) {
-      raw = raw.replaceAll(from, to);
-    }
-  }
-
-  if (raw === oldRaw) {
-    console.log(JSON.stringify({ sessionId, note: "No changes made — search strings not found", modified: false }, null, 2));
-    return;
-  }
-
-  // Recompute Content-Length if body changed
-  const lineEnd = "\r\n";
-  const separator = lineEnd + lineEnd;
-  const parts = raw.split(separator);
-  if (parts.length >= 2) {
-    const headerBlock = parts[0];
-    const bodyPart = parts.slice(1).join(separator);
-    const headerLines = headerBlock.split(lineEnd);
-    const clBytes = new TextEncoder().encode(bodyPart).length;
-    const newHeaders = headerLines.filter(h => !h.toLowerCase().startsWith("content-length:"));
-    newHeaders.push(`Content-Length: ${clBytes}`);
-    raw = newHeaders.join(lineEnd) + separator + bodyPart;
-  }
-
-  const newBase64 = Buffer.from(raw, "utf-8").toString("base64");
-
-  // Preserve existing settings
-  const existingSettings = (session.settings || {}) as any;
-  const settingsPayload: any = {
-    redirect: existingSettings.redirect || { strategy: "ALWAYS", max: 5 },
-    strategy: existingSettings.strategy || "ALL",
-    concurrency: existingSettings.concurrency || { workers: 1, delay: 0 },
-    retryOnFailure: existingSettings.retryOnFailure || { maximumRetries: 0, backoff: 0 },
-    closeConnection: existingSettings.closeConnection ?? false,
-    updateContentLength: true,
-  };
-
-  // Preserve payloads and placeholders if they exist
-  if (existingSettings.payloads?.length > 0) {
-    settingsPayload.payloads = existingSettings.payloads;
-  } else {
-    settingsPayload.payloads = [{ options: { simpleList: { list: [""] } }, preprocessors: [] }];
-  }
-  if (existingSettings.placeholders?.length > 0) {
-    settingsPayload.placeholders = existingSettings.placeholders;
-  } else {
-    settingsPayload.placeholders = [];
-  }
-
-  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
-    id: sessionId,
-    input: {
-      connection: session.connection,
-      raw: newBase64,
-      settings: settingsPayload,
-    },
-  });
-
-  console.log(JSON.stringify({
-    sessionId,
-    note: `Applied ${replacements.length} replacements, body modified`,
-    modified: true,
-  }, null, 2));
 }

--- a/skills/caido-mode/lib/commands/automate.ts
+++ b/skills/caido-mode/lib/commands/automate.ts
@@ -1,0 +1,379 @@
+/**
+ * Automate / Fuzz commands — rename, placeholders, payloads, results.
+ */
+import { getClient } from "../client";
+import {
+  CREATE_AUTOMATE_SESSION,
+  GET_AUTOMATE_SESSION,
+  START_AUTOMATE_TASK,
+  RENAME_AUTOMATE_SESSION,
+  UPDATE_AUTOMATE_SESSION,
+  AUTOMATE_SESSION_RESULTS,
+  AUTOMATE_SESSIONS,
+  AUTOMATE_TASKS,
+  DELETE_AUTOMATE_SESSION,
+  DUPLICATE_AUTOMATE_SESSION,
+  PAUSE_AUTOMATE_TASK,
+  RESUME_AUTOMATE_TASK,
+  CANCEL_AUTOMATE_TASK,
+  RENAME_AUTOMATE_ENTRY,
+  DELETE_AUTOMATE_ENTRIES,
+} from "../graphql";
+
+interface PlaceholderInput {
+  start: number;
+  end: number;
+}
+
+// ── Create automate session ──
+
+export async function cmdCreateAutomateSession(requestId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(CREATE_AUTOMATE_SESSION, {
+    input: { requestSource: { id: requestId } },
+  });
+  console.log(JSON.stringify((result as any).createAutomateSession.session, null, 2));
+}
+
+// ── Fuzz ──
+
+export async function cmdFuzz(sessionId: string) {
+  const client = await getClient();
+
+  const check = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const session = (check as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  console.log(JSON.stringify({
+    note: "Starting automate task.",
+    sessionId,
+  }, null, 2));
+
+  const startResult = await client.graphql.mutation(START_AUTOMATE_TASK, { automateSessionId: sessionId });
+  const task = (startResult as any).startAutomateTask.automateTask;
+
+  console.log(JSON.stringify({
+    sessionId,
+    taskId: task.id,
+    status: "started",
+  }, null, 2));
+}
+
+// ── Rename automate session ──
+
+export async function cmdRenameAutomateSession(sessionId: string, name: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(RENAME_AUTOMATE_SESSION, {
+    id: sessionId,
+    name,
+  });
+  console.log(JSON.stringify((result as any).renameAutomateSession.session, null, 2));
+}
+
+// ── Set placeholder (injection point) ──
+
+export async function cmdSetPlaceholder(
+  sessionId: string,
+  placeholders: PlaceholderInput[],
+  showRaw: boolean,
+  searchStr?: string,
+  searchLength?: number,
+) {
+  const client = await getClient();
+
+  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const session = (getResult as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  if (!session.raw) {
+    console.error("No raw request data in session");
+    process.exit(1);
+  }
+
+  const raw = Buffer.from(session.raw, "base64").toString("utf-8");
+
+  // Auto-compute placeholder from --search + --length
+  if (searchStr && searchLength !== undefined && placeholders.length === 0) {
+    const idx = raw.indexOf(searchStr);
+    if (idx === -1) {
+      console.error(`Search string not found in raw request: "${searchStr}"`);
+      showRaw = true;
+    } else {
+      const start = idx + searchStr.length;
+      const end = start + searchLength;
+      placeholders.push({ start, end });
+      console.log(JSON.stringify({
+        note: `Found "${searchStr}" at byte ${idx}, setting placeholder at [${start}-${end}]`,
+      }, null, 2));
+    }
+  }
+
+  if (showRaw) {
+    const escaped = raw.replace(/\r\n/g, "\\r\\n");
+    console.log(JSON.stringify({ raw: escaped }, null, 2));
+    const lines = raw.split("\r\n");
+    let pos = 0;
+    for (const line of lines) {
+      console.log(`  [${pos}-${pos + line.length}] ${line}`);
+      pos += line.length + 2;
+    }
+  }
+
+  if (placeholders.length === 0) {
+    return;
+  }
+
+  // Preserve existing payloads when setting placeholders
+  const existingSettings = session.settings as any;
+  let existingPayloads: any[] = [];
+  if (existingSettings?.payloads?.length > 0) {
+    existingPayloads = existingSettings.payloads.map((p: any) => ({
+      options: p.options,
+      preprocessors: [],
+    }));
+  }
+
+  const input: any = {
+    connection: session.connection,
+    raw: session.raw,
+    settings: {
+      payloads: existingPayloads,
+      placeholders: placeholders.map(p => ({ start: p.start, end: p.end })),
+      redirect: { strategy: "ALWAYS", max: 5 },
+      strategy: "ALL",
+      concurrency: { workers: 1, delay: 0 },
+      retryOnFailure: { maximumRetries: 0, backoff: 0 },
+      closeConnection: false,
+      updateContentLength: true,
+    },
+  };
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, { id: sessionId, input });
+
+  console.log(JSON.stringify({
+    sessionId,
+    placeholdersSet: placeholders.length,
+    placeholders,
+    updated: true,
+  }, null, 2));
+}
+
+// ── Set payload list ──
+
+export async function cmdSetPayload(sessionId: string, list: string[]) {
+  const client = await getClient();
+
+  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const session = (getResult as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  // Preserve existing placeholders when setting payloads
+  const existingSettings = session.settings as any;
+  let existingPlaceholders: { start: number; end: number }[] = [];
+  if (existingSettings?.placeholders?.length > 0) {
+    existingPlaceholders = existingSettings.placeholders.map((p: any) => ({ start: p.start, end: p.end }));
+  }
+
+  const input: any = {
+    connection: session.connection,
+    raw: session.raw,
+    settings: {
+      payloads: [
+        {
+          options: { simpleList: { list } },
+          preprocessors: [],
+        },
+      ],
+      placeholders: existingPlaceholders,
+      redirect: { strategy: "ALWAYS", max: 5 },
+      strategy: "ALL",
+      concurrency: { workers: 1, delay: 0 },
+      retryOnFailure: { maximumRetries: 0, backoff: 0 },
+      closeConnection: false,
+      updateContentLength: true,
+    },
+  };
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, { id: sessionId, input });
+
+  console.log(JSON.stringify({
+    sessionId,
+    payloadsSet: list.length,
+    payloads: list,
+    updated: true,
+  }, null, 2));
+}
+
+// ── Get automate results ──
+
+export async function cmdAutomateResults(sessionId: string) {
+  const client = await getClient();
+  const result = await client.graphql.query(AUTOMATE_SESSION_RESULTS, { id: sessionId });
+
+  const session = (result as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  const output: any = {
+    sessionId: session.id,
+    name: session.name,
+    entries: [],
+  };
+
+  for (const entry of session.entries) {
+    const entryOutput: any = {
+      entryId: entry.id,
+      entryName: entry.name,
+      requests: [],
+    };
+
+    for (const reqEdge of entry.requests.edges) {
+      const req = reqEdge.node;
+      const reqOutput: any = {
+        sequenceId: req.sequenceId,
+        payloads: req.payloads,
+        error: req.error || null,
+      };
+
+      if (req.request) {
+        reqOutput.method = req.request.method;
+        reqOutput.host = req.request.host;
+        reqOutput.path = req.request.path;
+        reqOutput.port = req.request.port;
+
+        if (req.request.response) {
+          reqOutput.response = {
+            statusCode: req.request.response.statusCode,
+            roundtrip: req.request.response.roundtripTime,
+            length: req.request.response.length,
+          };
+
+          if (req.request.response.raw) {
+            const rawResp = Buffer.from(req.request.response.raw, "base64").toString("utf-8");
+            const bodyIdx = rawResp.indexOf("\r\n\r\n");
+            if (bodyIdx >= 0) {
+              reqOutput.response.bodyPreview = rawResp.substring(bodyIdx + 4, bodyIdx + 500);
+            }
+          }
+        }
+      }
+
+      entryOutput.requests.push(reqOutput);
+    }
+
+    output.entries.push(entryOutput);
+  }
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+// ── List automate sessions ──
+
+export async function cmdAutomateSessions(limit: number = 20) {
+  const client = await getClient();
+  const result = await client.graphql.query(AUTOMATE_SESSIONS, { first: limit });
+  const sessions = (result as any).automateSessions;
+  if (!sessions || !sessions.edges?.length) {
+    console.log(JSON.stringify({ count: 0, sessions: [] }, null, 2));
+    return;
+  }
+  console.log(JSON.stringify({
+    count: sessions.count?.value ?? sessions.edges.length,
+    sessions: sessions.edges.map((e: any) => e.node),
+  }, null, 2));
+}
+
+// ── List automate tasks ──
+
+export async function cmdAutomateTasks(limit: number = 20) {
+  const client = await getClient();
+  const result = await client.graphql.query(AUTOMATE_TASKS, { first: limit });
+  const tasks = (result as any).automateTasks;
+  if (!tasks || !tasks.edges?.length) {
+    console.log(JSON.stringify({ count: 0, tasks: [] }, null, 2));
+    return;
+  }
+  console.log(JSON.stringify({
+    count: tasks.count?.value ?? tasks.edges.length,
+    tasks: tasks.edges.map((e: any) => e.node),
+  }, null, 2));
+}
+
+// ── Delete automate session ──
+
+export async function cmdDeleteAutomateSession(sessionId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(DELETE_AUTOMATE_SESSION, { id: sessionId });
+  console.log(JSON.stringify({
+    deletedId: (result as any).deleteAutomateSession.deletedId,
+    status: "deleted",
+  }, null, 2));
+}
+
+// ── Duplicate automate session ──
+
+export async function cmdDuplicateAutomateSession(sessionId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(DUPLICATE_AUTOMATE_SESSION, { id: sessionId });
+  console.log(JSON.stringify({
+    duped: (result as any).duplicateAutomateSession.session,
+    status: "created",
+  }, null, 2));
+}
+
+// ── Pause automate task ──
+
+export async function cmdPauseAutomateTask(taskId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(PAUSE_AUTOMATE_TASK, { id: taskId });
+  console.log(JSON.stringify((result as any).pauseAutomateTask, null, 2));
+}
+
+// ── Resume automate task ──
+
+export async function cmdResumeAutomateTask(taskId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(RESUME_AUTOMATE_TASK, { id: taskId });
+  console.log(JSON.stringify((result as any).resumeAutomateTask, null, 2));
+}
+
+// ── Cancel automate task ──
+
+export async function cmdCancelAutomateTask(taskId: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(CANCEL_AUTOMATE_TASK, { id: taskId });
+  console.log(JSON.stringify({
+    cancelledId: (result as any).cancelAutomateTask.cancelledId,
+    status: "cancelled",
+  }, null, 2));
+}
+
+// ── Rename automate entry ──
+
+export async function cmdRenameAutomateEntry(entryId: string, name: string) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(RENAME_AUTOMATE_ENTRY, { entryId, name });
+  console.log(JSON.stringify({
+    entry: (result as any).renameAutomateEntry.entry,
+    updated: true,
+  }, null, 2));
+}
+
+// ── Delete automate entries ──
+
+export async function cmdDeleteAutomateEntries(ids: string[]) {
+  const client = await getClient();
+  const result = await client.graphql.mutation(DELETE_AUTOMATE_ENTRIES, { ids });
+  console.log(JSON.stringify((result as any).deleteAutomateEntries, null, 2));
+}

--- a/skills/caido-mode/lib/commands/automate.ts
+++ b/skills/caido-mode/lib/commands/automate.ts
@@ -98,15 +98,26 @@ export async function cmdSetPlaceholder(
 
   const raw = Buffer.from(session.raw, "base64").toString("utf-8");
 
-  // Auto-compute placeholder from --search + --length
-  if (searchStr && searchLength !== undefined && placeholders.length === 0) {
+  // Auto-compute placeholder from --search
+  // Two modes:
+  //   --search <str>          : placeholder covers the found string
+  //   --search <str> --len <n>: placeholder covers n bytes after the string
+  if (searchStr && placeholders.length === 0) {
     const idx = raw.indexOf(searchStr);
     if (idx === -1) {
       console.error(`Search string not found in raw request: "${searchStr}"`);
       showRaw = true;
     } else {
-      const start = idx + searchStr.length;
-      const end = start + searchLength;
+      let start: number, end: number;
+      if (searchLength !== undefined) {
+        // Legacy mode: cover N bytes after the search string
+        start = idx + searchStr.length;
+        end = start + searchLength;
+      } else {
+        // Default mode: cover the search string itself
+        start = idx;
+        end = idx + searchStr.length;
+      }
       placeholders.push({ start, end });
       console.log(JSON.stringify({
         note: `Found "${searchStr}" at byte ${idx}, setting placeholder at [${start}-${end}]`,

--- a/skills/caido-mode/lib/commands/automate.ts
+++ b/skills/caido-mode/lib/commands/automate.ts
@@ -144,10 +144,13 @@ export async function cmdSetPlaceholder(
   const existingSettings = session.settings as any;
   let existingPayloads: any[] = [];
   if (existingSettings?.payloads?.length > 0) {
-    existingPayloads = existingSettings.payloads.map((p: any) => ({
-      options: p.options,
-      preprocessors: [],
-    }));
+    existingPayloads = existingSettings.payloads.map((p: any) => {
+      const opts: any = {};
+      if (p.options?.list) opts.simpleList = { list: p.options.list };
+      else if (p.options?.range) opts.number = { range: p.options.range, increments: p.options.increments, minLength: p.options.minLength };
+      else opts.simpleList = { list: [] };
+      return { options: opts, preprocessors: [] };
+    });
   }
 
   const input: any = {
@@ -387,4 +390,92 @@ export async function cmdDeleteAutomateEntries(ids: string[]) {
   const client = await getClient();
   const result = await client.graphql.mutation(DELETE_AUTOMATE_ENTRIES, { ids });
   console.log(JSON.stringify((result as any).deleteAutomateEntries, null, 2));
+}
+
+// ── Edit automate session body ──
+// Find/replace in the raw request body, update Content-Length
+
+export async function cmdEditAutomateBody(sessionId: string, replacements: string[]) {
+  if (replacements.length === 0) {
+    console.error("Error: --replace <from>:::<to> is required");
+    process.exit(1);
+  }
+
+  const client = await getClient();
+
+  const getResult = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const session = (getResult as any).automateSession;
+  if (!session) {
+    console.error(`Automate session ${sessionId} not found`);
+    process.exit(1);
+  }
+
+  let raw = Buffer.from(session.raw, "base64").toString("utf-8");
+  const oldRaw = raw;
+
+  for (const rep of replacements) {
+    const [from, to] = rep.split(":::");
+    if (from !== undefined && to !== undefined) {
+      raw = raw.replaceAll(from, to);
+    }
+  }
+
+  if (raw === oldRaw) {
+    console.log(JSON.stringify({ sessionId, note: "No changes made — search strings not found", modified: false }, null, 2));
+    return;
+  }
+
+  // Recompute Content-Length if body changed
+  const lineEnd = "\r\n";
+  const separator = lineEnd + lineEnd;
+  const parts = raw.split(separator);
+  if (parts.length >= 2) {
+    const headerBlock = parts[0];
+    const bodyPart = parts.slice(1).join(separator);
+    const headerLines = headerBlock.split(lineEnd);
+    const clBytes = new TextEncoder().encode(bodyPart).length;
+    const newHeaders = headerLines.filter(h => !h.toLowerCase().startsWith("content-length:"));
+    newHeaders.push(`Content-Length: ${clBytes}`);
+    raw = newHeaders.join(lineEnd) + separator + bodyPart;
+  }
+
+  const newBase64 = Buffer.from(raw, "utf-8").toString("base64");
+
+  // Preserve existing settings
+  const existingSettings = (session.settings || {}) as any;
+  const settingsPayload: any = {
+    redirect: existingSettings.redirect || { strategy: "ALWAYS", max: 5 },
+    strategy: existingSettings.strategy || "ALL",
+    concurrency: existingSettings.concurrency || { workers: 1, delay: 0 },
+    retryOnFailure: existingSettings.retryOnFailure || { maximumRetries: 0, backoff: 0 },
+    closeConnection: existingSettings.closeConnection ?? false,
+    updateContentLength: true,
+  };
+
+  // Preserve payloads and placeholders if they exist
+  if (existingSettings.payloads?.length > 0) {
+    settingsPayload.payloads = existingSettings.payloads;
+  } else {
+    settingsPayload.payloads = [{ options: { simpleList: { list: [""] } }, preprocessors: [] }];
+  }
+  if (existingSettings.placeholders?.length > 0) {
+    settingsPayload.placeholders = existingSettings.placeholders;
+  } else {
+    settingsPayload.placeholders = [];
+  }
+
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+    id: sessionId,
+    input: {
+      connection: session.connection,
+      raw: newBase64,
+      settings: settingsPayload,
+    },
+  });
+
+  console.log(JSON.stringify({
+    sessionId,
+    note: `Applied ${replacements.length} replacements, body modified`,
+    modified: true,
+  }, null, 2));
 }

--- a/skills/caido-mode/lib/commands/composite.ts
+++ b/skills/caido-mode/lib/commands/composite.ts
@@ -1,0 +1,539 @@
+/** Composite CLI commands — SDK-powered multi-step operations */
+
+import { getClient } from "../client";
+import { decodeRaw, formatHttpRaw } from "../output";
+import {
+  CREATE_AUTOMATE_SESSION,
+  GET_AUTOMATE_SESSION,
+  UPDATE_AUTOMATE_SESSION,
+  START_AUTOMATE_TASK,
+  AUTOMATE_SESSION_RESULTS,
+} from "../graphql";
+import {
+  cmdSetPlaceholder,
+  cmdSetPayload,
+  cmdFuzz,
+} from "./automate";
+import type { OutputOpts } from "../types";
+
+export interface IdorChainResult {
+  targetId: string;
+  requestId: string;
+  sessionId: string;
+  statusCode: number;
+  roundtrip: number;
+  length: number;
+  success: boolean;
+  error?: string;
+}
+
+export interface FuzzAutomateOptions {
+  strategy?: "ALL" | "SEQUENTIAL" | "PARALLEL" | "MATRIX";
+  workers?: number;
+  delay?: number;
+  redirectStrategy?: "NEVER" | "IN_SCOPE" | "SAME_SITE" | "ALWAYS";
+  followRedirects?: boolean;
+}
+
+export interface IdorChainOptions {
+  createFindings?: boolean;
+  findingTitlePrefix?: string;
+  findingDescription?: string;
+  dedupeKeyPrefix?: string;
+  maxConcurrent?: number;
+  outputOpts?: OutputOpts;
+}
+
+export interface BulkReplayOptions {
+  filter?: string; // HTTPQL filter
+  collectionId?: string;
+  rateLimit?: number; // requests per second
+  maxRequests?: number;
+  outputOpts?: OutputOpts;
+}
+
+/**
+ * IDOR Chain Testing
+ * 
+ * Takes a base authenticated request and tests IDOR against multiple target IDs.
+ * Creates a replay session for each target, modifies the path to swap the ID,
+ * and optionally creates findings for successful accesses.
+ * 
+ * Usage:
+ *   caido idor-chain <base-request-id> --ids "100,101,102,103" [--create-findings]
+ */
+export async function cmdIdorChain(
+  baseRequestId: string,
+  targetIds: string[],
+  options: IdorChainOptions = {}
+) {
+  const client = await getClient();
+  const {
+    createFindings = false,
+    findingTitlePrefix = "IDOR on",
+    findingDescription,
+    dedupeKeyPrefix = "idor",
+    maxConcurrent = 3,
+    outputOpts,
+  } = options;
+
+  console.error(`[*] Fetching base request ${baseRequestId}...`);
+  const base = await client.request.get(baseRequestId, { raw: true });
+  if (!base) {
+    console.error(`Error: Request ${baseRequestId} not found`);
+    process.exit(1);
+  }
+
+  const basePath = base.request.path;
+  const results: IdorChainResult[] = [];
+
+  // Extract the numeric ID pattern from the base path (e.g., /api/user/123 -> 123)
+  const idMatch = basePath.match(/\d+/);
+  if (!idMatch) {
+    console.error("Error: Could not extract numeric ID from base path. Use --path-template if needed.");
+    process.exit(1);
+  }
+  const originalId = idMatch[0];
+  console.error(`[*] Base path: ${basePath} (detected ID: ${originalId})`);
+
+  // Process targets with concurrency control
+  const queue = [...targetIds];
+  const running = new Set<Promise<void>>();
+
+  async function processNext() {
+    if (queue.length === 0) return;
+    
+    const targetId = queue.shift()!;
+    const promise = (async () => {
+      try {
+        const modifiedPath = basePath.replace(originalId, targetId);
+        console.error(`[*] Testing ${modifiedPath}...`);
+
+        const session = await client.replay.sessions.create({
+          requestSource: { id: baseRequestId },
+        });
+
+        const raw = decodeRaw(base.request.raw!);
+        if (!raw) throw new Error("No raw data");
+
+        // Modify path in raw request
+        const modifiedRaw = raw.replace(
+          new RegExp(`\\b${originalId}\\b`),
+          targetId
+        );
+
+        const result = await client.replay.send(session.id, {
+          raw: modifiedRaw,
+          connection: {
+            host: base.request.host,
+            port: base.request.port,
+            isTLS: base.request.isTls,
+          },
+        });
+
+        const statusCode = result.entry?.response?.statusCode ?? 0;
+        const roundtrip = result.entry?.response?.roundtripTime ?? 0;
+        const length = result.entry?.response?.length ?? 0;
+        const success = statusCode === 200 || statusCode === 201 || statusCode === 204;
+
+        const entry: IdorChainResult = {
+          targetId,
+          requestId: baseRequestId,
+          sessionId: session.id,
+          statusCode,
+          roundtrip,
+          length,
+          success,
+        };
+
+        // Rename session for traceability
+        await client.replay.sessions.rename(session.id, `idor-${targetId}-${baseRequestId}`);
+
+        if (createFindings && success) {
+          const dedupeKey = `${dedupeKeyPrefix}-${targetId}`;
+          const title = `${findingTitlePrefix} ${modifiedPath} (target: ${targetId})`;
+          try {
+            await client.finding.create({
+              requestId: baseRequestId,
+              title,
+              description: findingDescription || `IDOR allows access to ${modifiedPath} by changing ID to ${targetId}`,
+              dedupeKey,
+            });
+            console.error(`[+] Created finding: ${title}`);
+          } catch (e) {
+            console.error(`[!] Finding creation failed for ${targetId}: ${e}`);
+          }
+        }
+
+        results.push(entry);
+        console.error(`[${success ? "+" : "-"}] ${targetId}: ${statusCode} (${roundtrip}ms, ${length} bytes)`);
+      } catch (err: any) {
+        results.push({
+          targetId,
+          requestId: baseRequestId,
+          sessionId: "",
+          statusCode: 0,
+          roundtrip: 0,
+          length: 0,
+          success: false,
+          error: err.message,
+        });
+        console.error(`[!] ${targetId}: ${err.message}`);
+      }
+    })();
+
+    running.add(promise);
+    promise.finally(() => running.delete(promise));
+    await processNext();
+  }
+
+  // Start initial workers
+  const workers = Math.min(maxConcurrent, targetIds.length);
+  await Promise.all(Array(workers).fill(0).map(() => processNext()));
+  await Promise.all(running);
+
+  console.log(JSON.stringify({
+    baseRequestId,
+    totalTested: targetIds.length,
+    successful: results.filter(r => r.success).length,
+    results,
+  }, null, 2));
+}
+
+/**
+ * Full Automate Fuzzing Pipeline
+ * 
+ * One-command fuzzing: creates automate session, sets body markers,
+ * configures placeholders and payloads, runs fuzz, returns results.
+ * 
+ * Usage:
+ *   caido fuzz-automate <request-id> --payloads "payload1,payload2" 
+ *     [--strategy MATRIX] [--workers 5] [--delay 100]
+ */
+export async function cmdFuzzAutomate(
+  requestId: string,
+  payloads: string[],
+  options: FuzzAutomateOptions = {}
+) {
+  const client = await getClient();
+  const {
+    strategy = "MATRIX",
+    workers = 5,
+    delay = 100,
+    redirectStrategy = "NEVER",
+    followRedirects = false,
+  } = options;
+
+  console.error(`[*] Creating automate session from request ${requestId}...`);
+  
+  // Step 1: Create automate session
+  const createResult = await client.graphql.mutation(CREATE_AUTOMATE_SESSION, {
+    input: { requestSource: { id: requestId } },
+  });
+  const session = (createResult as any).createAutomateSession.session;
+  const sessionId = session.id;
+  console.error(`[+] Created automate session: ${sessionId}`);
+
+  // Step 2: Get current body to identify fuzz targets
+  const check = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const sessionData = (check as any).automateSession;
+  const rawBody = sessionData.raw;
+  if (!rawBody) {
+    console.error("Error: No raw body in automate session");
+    process.exit(1);
+  }
+
+  const body = decodeRaw(rawBody);
+  console.error(`[*] Raw body (${body.length} bytes)`);
+
+  // Step 3: Auto-detect or use provided FUZZ markers
+  // Strategy: replace boolean true/false and null values with "FUZZ" markers
+  let modifiedBody = body;
+  let markerCount = 0;
+  
+  // Replace common fuzz targets: true, false, null, numbers
+  const patterns = [
+    { from: ':true', to: ':"FUZZ"' },
+    { from: ':false', to: ':"FUZZ"' },
+    { from: ':null', to: ':"FUZZ"' },
+    { from: ':""', to: ':"FUZZ"' }, // empty strings
+  ];
+
+  for (const { from, to } of patterns) {
+    const regex = new RegExp(from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+    const matches = modifiedBody.match(regex);
+    if (matches) {
+      modifiedBody = modifiedBody.replace(regex, to);
+      markerCount += matches.length;
+    }
+  }
+
+  if (markerCount === 0) {
+    console.error("[!] No auto-detected fuzz targets. Consider manual edit-automate-body first.");
+  } else {
+    console.error(`[*] Auto-inserted ${markerCount} FUZZ marker(s)`);
+  }
+
+  // Step 3: Compute placeholder positions from FUZZ markers
+  const placeholders: { start: number; end: number }[] = [];
+  let searchPos = 0;
+  while (true) {
+    const idx = modifiedBody.indexOf("FUZZ", searchPos);
+    if (idx === -1) break;
+    placeholders.push({ start: idx, end: idx + 4 }); // "FUZZ" is 4 bytes
+    searchPos = idx + 4;
+  }
+
+  // Step 4: Set body, placeholders and payloads in one complete UPDATE
+  await client.graphql.mutation(UPDATE_AUTOMATE_SESSION, {
+    id: sessionId,
+    input: {
+      connection: sessionData.connection,
+      raw: Buffer.from(modifiedBody).toString("base64"),
+      settings: {
+        payloads: [{
+          options: { simpleList: { list: payloads } },
+          preprocessors: [],
+        }],
+        placeholders,
+        redirect: { strategy: "ALWAYS", max: 5 },
+        strategy: "ALL",
+        concurrency: { workers, delay },
+        retryOnFailure: { maximumRetries: 0, backoff: 0 },
+        closeConnection: false,
+        updateContentLength: true,
+      },
+    },
+  });
+  console.error(`[+] Configured body, ${placeholders.length} placeholder(s) and ${payloads.length} payload(s)`);
+
+  // Step 5: Verify settings
+  const verify = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
+  const vSession = (verify as any).automateSession;
+  const placeholderCount = vSession.settings?.placeholders?.length ?? 0;
+  // Payload count: check both simpleList and direct list (for different schema versions)
+  const payloadCount = vSession.settings?.payloads?.reduce((a: number, p: any) => {
+    const list = p.options?.simpleList?.list ?? p.options?.list ?? [];
+    return a + (Array.isArray(list) ? list.length : 0);
+  }, 0) ?? 0;
+  
+  if (placeholderCount === 0) {
+    console.error(`[!] No placeholders set. Use 'caido set-placeholder' to add injection points before fuzzing.`);
+    console.error(`[+] Automate session ${sessionId} created with payloads. Run 'caido fuzz ${sessionId}' after setting placeholders.`);
+    return;
+  }
+  if (payloadCount === 0) {
+    console.error(`Error: Payloads (${payloadCount}) not set correctly`);
+    process.exit(1);
+  }
+  console.error(`[+] Verified: ${placeholderCount} placeholders, ${payloadCount} payloads`);
+
+  // Step 6: Start fuzzing
+  console.error("[*] Starting fuzz task...");
+  const startResult = await client.graphql.mutation(START_AUTOMATE_TASK, { automateSessionId: sessionId });
+  const task = (startResult as any).startAutomateTask.automateTask;
+  const taskId = task.id;
+  console.error(`[+] Fuzz task started: ${taskId}`);
+
+  // Step 7: Poll for completion (simple polling - in production you'd want websocket)
+  console.error("[*] Waiting for completion...");
+  let completed = false;
+  let attempts = 0;
+  while (!completed && attempts < 120) { // 2 min max
+    await new Promise(r => setTimeout(r, 2000));
+    attempts++;
+    
+    const tasks = await client.task.list({ limit: 10 });
+    const taskList = Array.isArray(tasks) ? tasks : tasks.edges?.map((e: any) => e.node) ?? [];
+    const ourTask = taskList.find((t: any) => t.id === taskId);
+    if (ourTask && ourTask.status === "COMPLETED") {
+      completed = true;
+      break;
+    }
+    if (attempts % 5 === 0) console.error(`  ... waiting (${attempts * 2}s)`);
+  }
+
+  if (!completed) {
+    console.error("[!] Timeout waiting for fuzz completion. Check Caido UI for task status.");
+  }
+
+  // Step 8: Get results
+  console.error("[*] Fetching results...");
+  const results = await client.graphql.query(AUTOMATE_SESSION_RESULTS, { id: sessionId });
+  const entries = (results as any).automateSession.entries;
+
+  console.log(JSON.stringify({
+    sessionId,
+    taskId,
+    totalEntries: entries.length,
+    entries: entries.map((e: any) => ({
+      entryId: e.id,
+      entryName: e.name,
+      requestCount: e.requests?.edges?.length ?? 0,
+      requests: e.requests?.edges?.map((re: any) => ({
+        sequenceId: re.node.sequenceId,
+        statusCode: re.node.request?.response?.statusCode,
+        roundtrip: re.node.request?.response?.roundtripTime,
+        length: re.node.request?.response?.length,
+        payload: re.node.payloads?.[0]?.raw,
+        error: re.node.error,
+      })) || [],
+    })),
+  }, null, 2));
+}
+
+/**
+ * Bulk Replay from Collection or Filter
+ * 
+ * Replays all requests matching a filter or in a collection through the proxy.
+ * Useful for populating history withclean baselines after direct enumeration.
+ * 
+ * Usage:
+ *   caido bulk-replay --collection <id> [--rate 10] [--max 100]
+ *   caido bulk-replay --filter 'req.path.cont:"/api/"' [--rate 10]
+ */
+export async function cmdBulkReplay(
+  options: BulkReplayOptions = {}
+) {
+  const client = await getClient();
+  const {
+    filter,
+    collectionId,
+    rateLimit = 10,
+    maxRequests = 100,
+    outputOpts,
+  } = options;
+
+  if (!filter && !collectionId) {
+    console.error("Error: Either --filter or --collection required");
+    process.exit(1);
+  }
+
+  let requestIds: string[] = [];
+
+  if (collectionId) {
+    console.error(`[*] Fetching requests from collection ${collectionId}...`);
+    const collection = await client.replay.collections.get(collectionId);
+    // Get sessions in collection, then their requests
+    // This requires GraphQL since SDK may not expose collection->entries directly
+    const query = `
+      query($id: ID!) {
+        replayCollection(id: $id) {
+          entries { edges { node { request { id } } } }
+        }
+      }
+    `;
+    const result = await client.graphql.query({ query, variables: { id: collectionId } } as any);
+    requestIds = (result as any).replayCollection.entries.edges
+      .map((e: any) => e.node.request?.id)
+      .filter(Boolean);
+  } else if (filter) {
+    console.error(`[*] Searching requests with filter: ${filter}`);
+    const results = await client.request.list({ query: filter, limit: maxRequests });
+    requestIds = results.edges.map(e => String(e.node.id));
+  }
+
+  if (requestIds.length === 0) {
+    console.error("No requests found");
+    return;
+  }
+
+  console.error(`[*] Replaying ${requestIds.length} requests at ${rateLimit}/s...`);
+
+  const results = [];
+  const delay = 1000 / rateLimit;
+
+  for (let i = 0; i < requestIds.length; i++) {
+    const requestId = requestIds[i];
+    try {
+      const request = await client.request.get(requestId, { raw: true });
+      if (!request) continue;
+
+      const session = await client.replay.sessions.create({ requestSource: { id: requestId } });
+      const raw = decodeRaw(request.request.raw!);
+      
+      const result = await client.replay.send(session.id, {
+        raw,
+        connection: {
+          host: request.request.host,
+          port: request.request.port,
+          isTLS: request.request.isTls,
+        },
+      });
+
+      await client.replay.sessions.rename(session.id, `bulk-${requestId}-${Date.now()}`);
+
+      results.push({
+        requestId,
+        sessionId: session.id,
+        statusCode: result.entry?.response?.statusCode ?? 0,
+        roundtrip: result.entry?.response?.roundtripTime ?? 0,
+        length: result.entry?.response?.length ?? 0,
+      });
+
+      console.error(`[${i + 1}/${requestIds.length}] ${requestId}: ${result.entry?.response?.statusCode ?? "err"}`);
+    } catch (err: any) {
+      results.push({
+        requestId,
+        sessionId: "",
+        statusCode: 0,
+        error: err.message,
+      });
+      console.error(`[${i + 1}/${requestIds.length}] ${requestId}: ERROR - ${err.message}`);
+    }
+
+    if (i < requestIds.length - 1) {
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+
+  console.log(JSON.stringify({
+    total: requestIds.length,
+    successful: results.filter(r => r.statusCode > 0).length,
+    results,
+  }, null, 2));
+}
+
+/**
+ * Authenticated Endpoint Discovery
+ * 
+ * Searches for authenticated endpoints and tests IDOR on each.
+ * Combines search -> idor-chain for systematic auth surface testing.
+ * 
+ * Usage:
+ *   caido discover-auth --base-request <id> --pattern "/api/user" --ids "1,2,3"
+ */
+export async function cmdDiscoverAuth(
+  baseRequestId: string,
+  searchPattern: string,
+  targetIds: string[],
+  options: IdorChainOptions = {}
+) {
+  const client = await getClient();
+  
+  console.error(`[*] Searching for endpoints matching: ${searchPattern}`);
+  const searchResults = await client.request.list({ query: searchPattern, limit: 50 });
+  
+  console.log(JSON.stringify({
+    discoveredEndpoints: searchResults.edges.map(e => ({
+      id: e.node.id,
+      method: e.node.method,
+      path: e.node.path,
+      host: e.node.host,
+      statusCode: e.node.responseCode,
+    })),
+  }, null, 2));
+
+  // For each discovered endpoint, run idor-chain
+  for (const edge of searchResults.edges) {
+    console.error(`\n[*] Testing IDOR on ${edge.node.method} ${edge.node.path}...`);
+    await cmdIdorChain(String(edge.node.id), targetIds, options);
+  }
+}
+
+export {
+  cmdIdorChain as idorChain,
+  cmdFuzzAutomate as fuzzAutomate,
+  cmdBulkReplay as bulkReplay,
+  cmdDiscoverAuth as discoverAuth,
+};

--- a/skills/caido-mode/lib/commands/replay.ts
+++ b/skills/caido-mode/lib/commands/replay.ts
@@ -1,11 +1,8 @@
-/** Replay, Edit, Sessions, Collections, Automate/Fuzz commands */
+/** Replay, Edit, Sessions, Collections commands */
 
 import { getClient } from "../client";
 import { decodeRaw, formatHttpRaw } from "../output";
 import {
-  CREATE_AUTOMATE_SESSION,
-  GET_AUTOMATE_SESSION,
-  START_AUTOMATE_TASK,
   CREATE_REPLAY_SESSION_RAW,
 } from "../graphql";
 import type { OutputOpts } from "../types";
@@ -512,39 +509,4 @@ export async function cmdDeleteCollection(collectionId: string) {
   const client = await getClient();
   await client.replay.collections.delete(collectionId);
   console.log(JSON.stringify({ deleted: collectionId }, null, 2));
-}
-
-// -- Automate / Fuzz --
-
-export async function cmdCreateAutomateSession(requestId: string) {
-  const client = await getClient();
-  const result = await client.graphql.mutation(CREATE_AUTOMATE_SESSION, {
-    input: { requestSource: { id: requestId } },
-  });
-  console.log(JSON.stringify((result as any).createAutomateSession.session, null, 2));
-}
-
-export async function cmdFuzz(sessionId: string, payloads: string[]) {
-  const client = await getClient();
-
-  const check = await client.graphql.query(GET_AUTOMATE_SESSION, { id: sessionId });
-  const session = (check as any).automateSession;
-  if (!session) {
-    console.error(`Automate session ${sessionId} not found`);
-    process.exit(1);
-  }
-
-  console.log(JSON.stringify({
-    note: "Starting automate task with existing session settings. Configure payloads in Caido UI.",
-    sessionId,
-  }, null, 2));
-
-  const startResult = await client.graphql.mutation(START_AUTOMATE_TASK, { automateSessionId: sessionId });
-  const task = (startResult as any).startAutomateTask.automateTask;
-
-  console.log(JSON.stringify({
-    sessionId,
-    taskId: task.id,
-    status: "started",
-  }, null, 2));
 }

--- a/skills/caido-mode/lib/graphql.ts
+++ b/skills/caido-mode/lib/graphql.ts
@@ -68,6 +68,7 @@ export const GET_AUTOMATE_SESSION = gql`
       raw
       settings {
         payloads { options { ... on AutomateSimpleListPayload { list } } }
+        placeholders { start end }
       }
     }
   }
@@ -77,6 +78,152 @@ export const START_AUTOMATE_TASK = gql`
   mutation($automateSessionId: ID!) {
     startAutomateTask(automateSessionId: $automateSessionId) {
       automateTask { id paused }
+    }
+  }
+`;
+
+export const RENAME_AUTOMATE_SESSION = gql`
+  mutation($id: ID!, $name: String!) {
+    renameAutomateSession(id: $id, name: $name) {
+      session { id name }
+    }
+  }
+`;
+
+export const UPDATE_AUTOMATE_SESSION = gql`
+  mutation($id: ID!, $input: UpdateAutomateSessionInput!) {
+    updateAutomateSession(id: $id, input: $input) {
+      session { id name }
+    }
+  }
+`;
+
+export const AUTOMATE_SESSION_RESULTS = gql`
+  query($id: ID!) {
+    automateSession(id: $id) {
+      id
+      name
+      entries {
+        id
+        name
+        raw
+        requests(first: 100) {
+          edges {
+            node {
+              sequenceId
+              error
+              payloads { raw position }
+              request {
+                id
+                method
+                host
+                path
+                port
+                isTls
+                raw
+                response {
+                  statusCode
+                  raw
+                  roundtripTime
+                  length
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// ── Automate: list, delete, duplicate, control ──
+
+export const AUTOMATE_SESSIONS = gql`
+  query($first: Int, $after: String) {
+    automateSessions(first: $first, after: $after) {
+      edges {
+        node {
+          id
+          name
+          createdAt
+          settings { payloads { options { ... on AutomateSimpleListPayload { list } } } }
+        }
+        cursor
+      }
+      count { value }
+    }
+  }
+`;
+
+export const AUTOMATE_TASKS = gql`
+  query($first: Int, $after: String) {
+    automateTasks(first: $first, after: $after) {
+      edges {
+        node {
+          id
+          paused
+          entry { id name }
+        }
+        cursor
+      }
+      count { value }
+    }
+  }
+`;
+
+export const DELETE_AUTOMATE_SESSION = gql`
+  mutation($id: ID!) {
+    deleteAutomateSession(id: $id) {
+      deletedId
+    }
+  }
+`;
+
+export const DUPLICATE_AUTOMATE_SESSION = gql`
+  mutation($id: ID!) {
+    duplicateAutomateSession(id: $id) {
+      session { id name createdAt }
+    }
+  }
+`;
+
+export const PAUSE_AUTOMATE_TASK = gql`
+  mutation($id: ID!) {
+    pauseAutomateTask(id: $id) {
+      automateTask { id paused }
+    }
+  }
+`;
+
+export const RESUME_AUTOMATE_TASK = gql`
+  mutation($id: ID!) {
+    resumeAutomateTask(id: $id) {
+      automateTask { id paused }
+    }
+  }
+`;
+
+export const CANCEL_AUTOMATE_TASK = gql`
+  mutation($id: ID!) {
+    cancelAutomateTask(id: $id) {
+      cancelledId
+    }
+  }
+`;
+
+export const RENAME_AUTOMATE_ENTRY = gql`
+  mutation($entryId: ID!, $name: String!) {
+    renameAutomateEntry(id: $entryId, name: $name) {
+      entry { id name }
+    }
+  }
+`;
+
+export const DELETE_AUTOMATE_ENTRIES = gql`
+  mutation($ids: [ID!]!) {
+    deleteAutomateEntries(ids: $ids) {
+      deletedIds
+      errors { ... on UnknownIdUserError { id code } }
     }
   }
 `;

--- a/skills/caido-mode/lib/output.ts
+++ b/skills/caido-mode/lib/output.ts
@@ -2,8 +2,20 @@
 
 import type { OutputOpts } from "./types";
 
-export function decodeRaw(raw: Uint8Array | undefined): string {
-  if (!raw || raw.length === 0) return "";
+export function decodeRaw(raw: string | Uint8Array | undefined): string {
+  if (!raw || (typeof raw === "string" && raw.length === 0) || (raw instanceof Uint8Array && raw.length === 0)) return "";
+  
+  // If raw is a base64 string, decode it first
+  if (typeof raw === "string") {
+    try {
+      return Buffer.from(raw, "base64").toString("utf-8");
+    } catch {
+      // If not valid base64, return as-is (might already be decoded)
+      return raw;
+    }
+  }
+  
+  // Uint8Array path
   return new TextDecoder().decode(raw);
 }
 


### PR DESCRIPTION
- Add 8 new GraphQL operations: list sessions/tasks, delete/duplicate sessions, pause/resume/cancel tasks, rename/delete entries
- Add CLI commands: automate-sessions, automate-tasks, delete-automate-session, duplicate-automate-session, pause-task, resume-task, cancel-task-automate, rename-automate-entry, delete-automate-entries
- Fix: Count scalar is object type (Count.value) in queries
- Fix: list/query client method mismatch (mutation -> query)
- Doc: CRITICAL guidance on placeholder byte ranges preserving JSON structure
- Doc: FUZZ marker pattern for valid JSON output during fuzzing
- Doc: payloads must not carry their own quotes when body provides them